### PR TITLE
feat(`fill`): noop fills

### DIFF
--- a/src/fill.rs
+++ b/src/fill.rs
@@ -3,14 +3,6 @@ use revm::{
     Database, Evm,
 };
 
-/// A no-op transaction filler.
-#[derive(Debug)]
-pub struct NoopTx;
-
-impl Tx for NoopTx {
-    fn fill_tx_env(&self, _: &mut TxEnv) {}
-}
-
 /// A no-op block filler.
 #[derive(Debug)]
 pub struct NoopBlock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ mod evm;
 pub use evm::Trevm;
 
 mod fill;
-pub use fill::{Block, Cfg, NoopBlock, NoopCfg, NoopTx, Tx};
+pub use fill::{Block, Cfg, NoopBlock, NoopCfg, Tx};
 
 mod lifecycle;
 pub use lifecycle::{


### PR DESCRIPTION
Closes #2. Implements `Noop` structs for `Cfg`/`Block` filler traits, for cases where only simple sims are needed without setting any of these.