### PR TITLE
Lower-level APIs

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,0 +1,177 @@
+use std::collections::HashMap;
+
+use alloy_primitives::{Address, B256, U256};
+use revm::{
+    primitives::{Account, AccountInfo, Bytecode, EvmStorageSlot},
+    Database, DatabaseCommit,
+};
+
+/// Extension trait for [`revm::Evm`] with convenience functions for reading
+/// and modifying state.
+pub trait EvmExtUnchecked<Db: Database> {
+    /// Get a mutable reference to the database.
+    fn db_mut_ext(&mut self) -> &mut Db;
+
+    /// Load an account from the database.
+    fn account(&mut self, address: Address) -> Result<Account, Db::Error> {
+        let info = self.db_mut_ext().basic(address)?;
+        let created = info.is_none();
+        let mut acct = Account { info: info.unwrap_or_default(), ..Default::default() };
+        if created {
+            acct.mark_created();
+        }
+        Ok(acct)
+    }
+
+    /// Load a storage slot from an account.
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Db::Error> {
+        self.db_mut_ext().storage(address, index)
+    }
+
+    /// Load the bytecode for a contract. Returns empty bytecode if the account
+    /// does not currently have contract code.
+    fn bytecode(&mut self, code_hash: B256) -> Result<Bytecode, Db::Error> {
+        self.db_mut_ext().code_by_hash(code_hash)
+    }
+
+    /// Modify multiple accounts with a closure and commit the modified
+    /// accounts.
+    fn modify_accounts<I, F>(
+        &mut self,
+        changes: I,
+        f: F,
+    ) -> Result<HashMap<Address, AccountInfo>, Db::Error>
+    where
+        I: IntoIterator<Item = Address>,
+        F: Fn(&mut AccountInfo),
+        Db: DatabaseCommit,
+    {
+        let mut state = HashMap::default();
+        let mut old = HashMap::default();
+        for account in changes.into_iter() {
+            let mut acct = self.account(account)?;
+            old.insert(account, acct.info.clone());
+            f(&mut acct.info);
+            acct.mark_touch();
+            state.insert(account, acct);
+        }
+        self.db_mut_ext().commit(state);
+        Ok(old)
+    }
+
+    /// Modify an account with a closure and commit the modified account.
+    fn modify_account<F>(&mut self, address: Address, f: F) -> Result<AccountInfo, Db::Error>
+    where
+        F: FnOnce(&mut AccountInfo),
+        Db: DatabaseCommit,
+    {
+        let mut acct = self.account(address)?;
+        let old = acct.info.clone();
+        f(&mut acct.info);
+        acct.mark_touch();
+        let changes = [(address, acct)].into_iter().collect();
+        self.db_mut_ext().commit(changes);
+        Ok(old)
+    }
+
+    /// Set the storage value of an account, returning the previous value.
+    fn set_storage(&mut self, address: Address, index: U256, value: U256) -> Result<U256, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        let mut acct = self.account(address)?;
+        let old = self.storage(address, index)?;
+
+        let change = EvmStorageSlot::new_changed(old, value);
+        acct.storage.insert(index, change);
+        acct.mark_touch();
+
+        let changes = [(address, acct)].into_iter().collect();
+        self.db_mut_ext().commit(changes);
+        Ok(old)
+    }
+
+    /// Set the bytecode for an account, returns the previous bytecode.
+    fn set_bytecode(
+        &mut self,
+        address: Address,
+        bytecode: Bytecode,
+    ) -> Result<Option<Bytecode>, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        let mut acct = self.account(address)?;
+        let old = self.db_mut_ext().code_by_hash(acct.info.code_hash).map(|old| {
+            if old.is_empty() {
+                None
+            } else {
+                Some(old)
+            }
+        })?;
+        acct.info.code_hash = bytecode.hash_slow();
+        acct.info.code = Some(bytecode);
+        acct.mark_touch();
+
+        let changes = [(address, acct)].into_iter().collect();
+        self.db_mut_ext().commit(changes);
+        Ok(old)
+    }
+
+    /// Increase the balance of an account, returning the previous balance.
+    fn increase_balance(&mut self, address: Address, amount: U256) -> Result<U256, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.balance = info.balance.saturating_add(amount))
+            .map(|info| info.balance)
+    }
+
+    /// Decrease the balance of an account, returning the previous balance.
+    fn decrease_balance(&mut self, address: Address, amount: U256) -> Result<U256, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.balance = info.balance.saturating_sub(amount))
+            .map(|info| info.balance)
+    }
+
+    /// Set the balance of an account, returning the previous balance.
+    fn set_balance(&mut self, address: Address, amount: U256) -> Result<U256, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.balance = amount).map(|info| info.balance)
+    }
+
+    /// Set the nonce of an account, returning the previous nonce.
+    fn set_nonce(&mut self, address: Address, nonce: u64) -> Result<u64, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.nonce = nonce).map(|info| info.nonce)
+    }
+
+    /// Increment the nonce of an account, returning the new nonce.
+    fn increment_nonce(&mut self, address: Address) -> Result<u64, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.nonce = info.nonce.saturating_add(1))
+            .map(|info| info.nonce)
+    }
+
+    /// Decrement the nonce of an account, returning the new nonce.
+    fn decrement_nonce(&mut self, address: Address) -> Result<u64, Db::Error>
+    where
+        Db: DatabaseCommit,
+    {
+        self.modify_account(address, |info| info.nonce = info.nonce.saturating_sub(1))
+            .map(|info| info.nonce)
+    }
+}
+
+impl<Ext, Db: Database> EvmExtUnchecked<Db> for revm::Evm<'_, Ext, Db> {
+    fn db_mut_ext(&mut self) -> &mut Db {
+        self.db_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,9 @@
 mod evm;
 pub use evm::Trevm;
 
+mod ext;
+pub use ext::EvmExtUnchecked;
+
 mod fill;
 pub use fill::{Block, Cfg, NoopBlock, NoopCfg, Tx};
 

--- a/src/states.rs
+++ b/src/states.rs
@@ -65,8 +65,7 @@ pub type EvmTransacted<'a, Ext, Db, C> = Trevm<'a, Ext, Db, TransactedState<C>>;
 pub type EvmErrored<'a, Ext, Db, C, E = <C as BlockContext<Ext, Db>>::Error> =
     Trevm<'a, Ext, Db, ErroredState<C, E>>;
 
-#[allow(dead_code)]
-#[allow(unnameable_types)]
+#[allow(unnameable_types, dead_code, unreachable_pub)]
 pub(crate) mod sealed {
     use revm::primitives::ResultAndState;
 
@@ -134,13 +133,11 @@ pub(crate) mod sealed {
     }
 
     /// Trait for states where block execution can be started.
-    #[allow(unnameable_types)]
     pub trait NeedsBlock {}
     impl NeedsBlock for NeedsFirstBlock {}
     impl NeedsBlock for NeedsNextBlock {}
 
     /// Trait for states where thcare outputs vec is non-empty.
-    #[allow(unnameable_types)]
     pub trait HasOutputs {}
     impl HasOutputs for NeedsNextBlock {}
     impl<T> HasOutputs for NeedsTx<T> {}
@@ -148,15 +145,81 @@ pub(crate) mod sealed {
     impl<T, E> HasOutputs for ErroredState<T, E> {}
     impl<T> HasOutputs for Ready<T> {}
 
-    #[allow(unnameable_types)]
     pub trait HasCfg {}
-    #[allow(unnameable_types)]
     impl HasCfg for NeedsFirstBlock {}
     impl HasCfg for NeedsNextBlock {}
     impl<T> HasCfg for NeedsTx<T> {}
     impl<T> HasCfg for TransactedState<T> {}
     impl<T, E> HasCfg for ErroredState<T, E> {}
     impl<T> HasCfg for Ready<T> {}
+
+    pub trait HasContext {
+        type Context;
+
+        fn context(&self) -> &Self::Context;
+
+        fn context_mut(&mut self) -> &mut Self::Context;
+    }
+
+    impl<T> HasContext for NeedsTx<T> {
+        type Context = T;
+
+        fn context(&self) -> &Self::Context {
+            &self.0
+        }
+
+        fn context_mut(&mut self) -> &mut Self::Context {
+            &mut self.0
+        }
+    }
+
+    impl<T> HasContext for BlockComplete<T> {
+        type Context = T;
+
+        fn context(&self) -> &Self::Context {
+            &self.0
+        }
+
+        fn context_mut(&mut self) -> &mut Self::Context {
+            &mut self.0
+        }
+    }
+
+    impl<T> HasContext for TransactedState<T> {
+        type Context = T;
+
+        fn context(&self) -> &Self::Context {
+            &self.context
+        }
+
+        fn context_mut(&mut self) -> &mut Self::Context {
+            &mut self.context
+        }
+    }
+
+    impl<T, E> HasContext for ErroredState<T, E> {
+        type Context = T;
+
+        fn context(&self) -> &Self::Context {
+            &self.context
+        }
+
+        fn context_mut(&mut self) -> &mut Self::Context {
+            &mut self.context
+        }
+    }
+
+    impl<T> HasContext for Ready<T> {
+        type Context = T;
+
+        fn context(&self) -> &Self::Context {
+            &self.0
+        }
+
+        fn context_mut(&mut self) -> &mut Self::Context {
+            &mut self.0
+        }
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
Adds 2 unchecked APIs:

- an Ext trait for the EVM that allows shortcut state manipulation
- mutable and via-closure access to block contexts on Trevm

Motivation:
Context control flow takes `&mut Evm`, rather than `&mut Trevm` (as the latter would require double-mutable borrowing, or adding an ugly trevm `InContext` state). Extra low-level APIs make it easier to implement complex logic in block contexts, and more complex lifecycles relying on the context