### PR TITLE
feat(`driver`): `BundleDriver` for driving bundles to completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ alloy-consensus = { version = "0.2", features = ["k256"] }
 alloy-eips = "0.2.0"
 alloy-primitives = "0.7.6"
 alloy-rpc-types-eth = "0.2.0"
+alloy-rpc-types-mev = "0.2.0"
 alloy-sol-types = "0.7.7"
 revm = { version = "12.0.0", default-features = false, features = ["std"] }
 zenith-types = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.4.0"
+version = "0.5.0"
 rust-version = "1.79.0"
 edition = "2021"
 authors = ["init4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,11 @@ alloy-primitives = "0.7.6"
 alloy-rpc-types-eth = "0.2.0"
 alloy-rpc-types-mev = "0.2.0"
 alloy-sol-types = "0.7.7"
+alloy-rlp = { version = "0.3", default-features = false }
 revm = { version = "12.0.0", default-features = false, features = ["std"] }
 zenith-types = "0.3"
+
+thiserror = "1.0"
 
 [dev-dependencies]
 revm = { version = "12.0.0", features = ["test-utils", "serde-json", "std", "alloydb"] }
@@ -47,7 +50,6 @@ alloy-transport = "0.2"
 alloy-signer = { version = "0.1", default-features = false }
 alloy-signer-local = { version = "0.1", default-features = false }
 
-alloy-rlp = { version = "0.3", default-features = false }
 
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ alloy-primitives = "0.7.6"
 alloy-rpc-types-eth = "0.2.0"
 alloy-rpc-types-mev = "0.2.0"
 alloy-sol-types = "0.7.7"
-alloy-rlp = { version = "0.3", default-features = false }
 revm = { version = "12.0.0", default-features = false, features = ["std"] }
 zenith-types = "0.3"
 
@@ -50,6 +49,7 @@ alloy-transport = "0.2"
 alloy-signer = { version = "0.1", default-features = false }
 alloy-signer-local = { version = "0.1", default-features = false }
 
+alloy-rlp = { version = "0.3", default-features = false }
 
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -333,6 +333,8 @@ impl Block for BundleBlockFiller {
     fn fill_block_env(&self, block_env: &mut revm::primitives::BlockEnv) {
         if let Some(timestamp) = self.timestamp {
             block_env.timestamp = U256::from(timestamp);
+        } else {
+            block_env.timestamp += U256::from(12);
         }
         if let Some(gas_limit) = self.gas_limit {
             block_env.gas_limit = U256::from(gas_limit);

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::{Block, BundleDriver, DriveBundleResult};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::BlockNumberOrTag;
@@ -11,8 +13,14 @@ use thiserror::Error;
 enum BundleError<Db: revm::Database> {
     #[error("revm block number must match the bundle block number")]
     BlockNumberMimatch,
-    #[error(transparent)]
-    DatabaseError(#[from] EVMError<Db::Error>),
+    #[error("Internal EVM Error")]
+    EVMError { inner: EVMError<Db::Error> },
+}
+
+impl<Db: revm::Database> From<EVMError<Db::Error>> for BundleError<Db> {
+    fn from(inner: EVMError<Db::Error>) -> Self {
+        Self::EVMError { inner }
+    }
 }
 
 /// A block filler for the bundle, used to fill in the block data specified for the bundle.

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -1,13 +1,127 @@
 use crate::{Block, BundleDriver, DriveBundleResult};
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{Transaction, TxEnvelope};
 use alloy_eips::{eip2718::Decodable2718, BlockNumberOrTag};
-use alloy_primitives::{bytes::Buf, U256};
-use alloy_rpc_types_mev::{EthCallBundle, EthSendBundle};
+use alloy_primitives::{bytes::Buf, Address, TxKind, U256};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult, EthSendBundle};
 use revm::primitives::{EVMError, ExecutionResult};
 use thiserror::Error;
 
+/// A bundle simulator which can be used to drive a bundle with a [BundleDriver] and accumulate the results of the bundle.
+pub struct BundleSimulator<B, R> {
+    pub bundle: B,
+    pub response: R,
+}
+
+impl<B, R> BundleSimulator<B, R> {
+    pub fn new (bundle: B, response: R) -> Self {
+        Self {
+            bundle,
+            response,
+        }
+    }
+}
+
+impl<Ext> BundleDriver<Ext> for BundleSimulator<EthCallBundle, EthCallBundleResponse> {
+    type Error<Db: revm::Database> = BundleError<Db>;
+
+    fn run_bundle<'a, Db: revm::Database + revm::DatabaseCommit>(
+            &mut self,
+            trevm: crate::EvmNeedsTx<'a, Ext, Db>,
+        ) -> DriveBundleResult<'a, Ext, Db, Self> {
+        // 1. Check if the block we're in is valid for this bundle. Both must match
+        if trevm.inner().block().number.to::<u64>() != self.bundle.block_number {
+            return Err(trevm.errored(BundleError::BlockNumberMismatch));
+        }
+
+        let bundle_filler = BundleBlockFiller::from(self.bundle.clone());
+
+        let run_result = trevm.try_with_block(&bundle_filler, |trevm| {
+            let mut trevm = trevm;
+
+            let txs = self
+                .bundle
+                .txs
+                .iter()
+                .map(|tx| TxEnvelope::decode_2718(&mut tx.chunk()))
+                .collect::<Result<Vec<_>, _>>();
+            let txs = match txs {
+                Ok(txs) => txs,
+                Err(e) => return Err(trevm.errored(BundleError::TransactionDecodingError(e))),
+            };
+
+            for tx in txs.iter() {
+                let run_result = trevm.run_tx(tx);
+
+                match run_result {
+                    // return immediately if errored
+                    Err(e) => {
+                        return Err(e.map_err(|e| BundleError::EVMError { inner: e }));
+                    }
+                    // Accept + accumulate state
+                    Ok(res) => match res.result() {
+                        ExecutionResult::Revert { .. } | ExecutionResult::Halt { .. } => {
+                            return Err(res.errored(BundleError::BundleReverted));
+                        }
+                        ExecutionResult::Success { .. } => {
+                            let (execution_result, committed_trevm) = res.accept();
+                            let block_env = committed_trevm.inner().block();
+
+                            let from_address = tx.recover_signer().map_err(|e| BundleError::TransactionSenderRecoveryError(e));
+                            let from_address = match from_address {
+                                Ok(addr) => addr,
+                                Err(e) => return Err(committed_trevm.errored(e)),
+                            };
+
+                            let mut tx_response = EthCallBundleTransactionResult::default();
+                            tx_response.tx_hash = *tx.tx_hash();
+                            tx_response.value = execution_result.output().cloned();
+                            tx_response.gas_used = execution_result.gas_used();
+                            tx_response.from_address = from_address;
+                            tx_response.to_address = match tx.to() {
+                                TxKind::Call(to) => Some(to),
+                                _ => Some(Address::ZERO),
+                            };
+                            tx_response.gas_price = match tx {
+                                TxEnvelope::Legacy(tx) => U256::from(tx.tx().gas_price),
+                                TxEnvelope::Eip2930(tx) => U256::from(tx.tx().gas_price),
+                                TxEnvelope::Eip1559(tx) => U256::from(tx.tx().effective_gas_price(Some(block_env.basefee.to::<u64>()))),
+                                TxEnvelope::Eip4844(_) => U256::ZERO,
+                                _ => panic!("Unsupported transaction type"),
+                            };
+                            tx_response.gas_fees = match tx {
+                                TxEnvelope::Legacy(tx) => U256::from(tx.tx().gas_price) * U256::from(execution_result.gas_used()),
+                                TxEnvelope::Eip2930(tx) => U256::from(tx.tx().gas_price) * U256::from(execution_result.gas_used()),
+                                TxEnvelope::Eip1559(tx) => (block_env.basefee +  U256::from(tx.tx().max_priority_fee_per_gas)) * U256::from(execution_result.gas_used()),
+                                TxEnvelope::Eip4844(_) => U256::ZERO,
+                                _ => panic!("Unsupported transaction type"),
+                            };
+
+                            trevm = committed_trevm;
+                        }
+                    },
+                }
+            }
+
+            // return the final state
+            Ok(trevm)
+        });
+
+        match run_result {
+            Ok(trevm) => Ok(trevm),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn post_bundle<Db: revm::Database + revm::DatabaseCommit>(
+            &mut self,
+            _trevm: &crate::EvmNeedsTx<'_, Ext, Db>,
+        ) -> Result<(), Self::Error<Db>> {
+       Ok(()) 
+    }
+}
+
 /// Possible errors that can occur while driving a bundle.
-#[derive(Clone, Error)]
+#[derive(Error)]
 pub enum BundleError<Db: revm::Database> {
     /// The block number of the bundle does not match the block number of the revm block configuration.
     #[error("revm block number must match the bundle block number")]
@@ -21,6 +135,9 @@ pub enum BundleError<Db: revm::Database> {
     /// An error occurred while decoding a transaction contained in the bundle.
     #[error("transaction decoding error")]
     TransactionDecodingError(#[from] alloy_eips::eip2718::Eip2718Error),
+    /// An error ocurred while recovering the sender of a transaction
+    #[error("transaction sender recovery error")]
+    TransactionSenderRecoveryError(#[from] alloy_primitives::SignatureError),
     /// An error occurred while running the EVM.
     #[error("internal EVM Error")]
     EVMError {
@@ -42,6 +159,7 @@ impl<Db: revm::Database> std::fmt::Debug for BundleError<Db> {
             Self::BlockNumberMismatch => write!(f, "BlockNumberMismatch"),
             Self::BundleReverted => write!(f, "BundleReverted"),
             Self::TransactionDecodingError(e) => write!(f, "TransactionDecodingError({:?})", e),
+            Self::TransactionSenderRecoveryError(e) => write!(f, "TransactionSenderRecoveryError({:?})", e),
             Self::EVMError { .. } => write!(f, "EVMError"),
         }
     }

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -1,5 +1,3 @@
-use std::{f32::consts::E, fmt::Debug};
-
 use crate::{Block, BundleDriver, DriveBundleResult};
 use alloy_consensus::TxEnvelope;
 use alloy_eips::BlockNumberOrTag;
@@ -9,7 +7,7 @@ use alloy_rpc_types_mev::EthCallBundle;
 use revm::primitives::{EVMError, ExecutionResult};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Error)]
+#[derive(Clone, Error)]
 enum BundleError<Db: revm::Database> {
     #[error("revm block number must match the bundle block number")]
     BlockNumberMismatch,
@@ -24,6 +22,17 @@ enum BundleError<Db: revm::Database> {
 impl<Db: revm::Database> From<EVMError<Db::Error>> for BundleError<Db> {
     fn from(inner: EVMError<Db::Error>) -> Self {
         Self::EVMError { inner }
+    }
+}
+
+impl<Db: revm::Database> std::fmt::Debug for BundleError<Db> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BlockNumberMismatch => write!(f, "BlockNumberMismatch"),
+            Self::BundleReverted => write!(f, "BundleReverted"),
+            Self::TransactionDecodingError(e) => write!(f, "TransactionDecodingError({:?})", e),
+            Self::EVMError { .. } => write!(f, "EVMError"),
+        }
     }
 }
 

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -1,8 +1,7 @@
 use crate::{Block, BundleDriver, DriveBundleResult};
 use alloy_consensus::TxEnvelope;
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{eip2718::Decodable2718, BlockNumberOrTag};
 use alloy_primitives::U256;
-use alloy_rlp::Decodable;
 use alloy_rpc_types_mev::EthCallBundle;
 use revm::primitives::{EVMError, ExecutionResult};
 use thiserror::Error;
@@ -18,7 +17,7 @@ pub enum BundleError<Db: revm::Database> {
     BundleReverted,
     /// An error occurred while decoding a transaction contained in the bundle.
     #[error("transaction decoding error")]
-    TransactionDecodingError(#[from] alloy_rlp::Error),
+    TransactionDecodingError(#[from] alloy_eips::eip2718::Eip2718Error),
     /// An error occurred while running the EVM.
     #[error("internal EVM Error")]
     EVMError {
@@ -104,7 +103,7 @@ impl<Ext> BundleDriver<Ext> for EthCallBundle {
             let mut trevm = trevm;
 
             for raw_tx in self.txs.clone().into_iter() {
-                let tx = TxEnvelope::decode(&mut raw_tx.to_vec().as_slice());
+                let tx = TxEnvelope::decode_2718(&mut raw_tx.to_vec().as_slice());
 
                 let tx = match tx {
                     Ok(tx) => tx,

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -1,0 +1,104 @@
+use crate::{Block, BundleDriver, DriveBundleResult};
+use alloy_consensus::TxEnvelope;
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::U256;
+use alloy_rlp::Decodable;
+use alloy_rpc_types_mev::EthCallBundle;
+use revm::primitives::EVMError;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Error)]
+enum BundleError<Db: revm::Database> {
+    #[error("revm block number must match the bundle block number")]
+    BlockNumberMimatch,
+    #[error(transparent)]
+    DatabaseError(#[from] EVMError<Db::Error>),
+}
+
+/// A block filler for the bundle, used to fill in the block data specified for the bundle.
+#[derive(Clone, Debug)]
+struct BundleBlockFiller {
+    pub block_number: BlockNumberOrTag,
+    pub timestamp: Option<u64>,
+    pub gas_limit: Option<u64>,
+    pub difficulty: Option<U256>,
+    pub base_fee: Option<u128>,
+}
+
+impl Block for BundleBlockFiller {
+    fn fill_block_env(&self, block_env: &mut revm::primitives::BlockEnv) {
+        if let Some(timestamp) = self.timestamp {
+            block_env.timestamp = U256::from(timestamp);
+        }
+        if let Some(gas_limit) = self.gas_limit {
+            block_env.gas_limit = U256::from(gas_limit);
+        }
+        if let Some(difficulty) = self.difficulty {
+            block_env.difficulty = difficulty;
+        }
+        if let Some(base_fee) = self.base_fee {
+            block_env.basefee = U256::from(base_fee);
+        }
+    }
+}
+
+impl From<EthCallBundle> for BundleBlockFiller {
+    fn from(bundle: EthCallBundle) -> Self {
+        Self {
+            block_number: bundle.state_block_number,
+            timestamp: bundle.timestamp,
+            gas_limit: bundle.gas_limit,
+            difficulty: bundle.difficulty,
+            base_fee: bundle.base_fee,
+        }
+    }
+}
+
+impl<Ext> BundleDriver<Ext> for EthCallBundle {
+    type Error<Db: revm::Database> = BundleError<Db>;
+
+    fn run_bundle<'a, Db: revm::Database + revm::DatabaseCommit>(
+        &mut self,
+        trevm: crate::EvmNeedsTx<'a, Ext, Db>,
+    ) -> DriveBundleResult<'a, Ext, Db, Self> {
+        // 1. Check if the block we're in is valid for this bundle. Both must match
+        if trevm.inner().block().number.to() != self.block_number {
+            return Err(trevm.errored(BundleError::BlockNumberMimatch));
+        }
+
+        let bundle_filler = BundleBlockFiller::from(self.clone());
+
+        let trevm = trevm.with_block(
+            |trevm| {
+                let mut trevm = trevm;
+
+                for raw_tx in self.txs.into_iter() {
+                    let tx = TxEnvelope::decode(&mut raw_tx.to_vec().as_slice()).unwrap();
+                    let run_result = trevm.run_tx(&tx);
+
+                    match run_result {
+                        // return immediately if errored
+                        Err(e) => return e,
+                        // Accept the state, and move on
+                        Ok(res) => {
+                            trevm = res.accept_state();
+                        }
+                    }
+                }
+
+                // return the final state
+                trevm
+            },
+            &bundle_filler,
+        );
+
+        Ok(trevm)
+    }
+
+    fn post_bundle<Db: revm::Database + revm::DatabaseCommit>(
+        &mut self,
+        _trevm: &crate::EvmNeedsTx<'_, Ext, Db>,
+    ) -> Result<(), Self::Error<Db>> {
+        Ok(())
+    }
+}

--- a/src/driver/bundle.rs
+++ b/src/driver/bundle.rs
@@ -1,0 +1,25 @@
+use crate::{states::EvmBundleDriverErrored, EvmNeedsTx};
+use revm::{primitives::EVMError, Database, DatabaseCommit};
+
+/// The result of driving a bundle to completion.
+pub type DriveBundleResult<'a, Ext, Db, T> =
+    Result<EvmNeedsTx<'a, Ext, Db>, EvmBundleDriverErrored<'a, Ext, Db, T>>;
+
+/// Driver for a bundle of transactions. This trait allows a type to specify the
+/// entire lifecycle of a bundle, simulating the entire list of transactions.
+pub trait BundleDriver<Ext> {
+    /// An error type for this driver.
+    type Error<Db: Database>: std::error::Error + From<EVMError<Db::Error>>;
+
+    /// Run the transactions contained in the bundle.
+    fn run_txns<'a, Db: Database + DatabaseCommit>(
+        &mut self,
+        trevm: EvmNeedsTx<'a, Ext, Db>,
+    ) -> DriveBundleResult<'a, Ext, Db, Self>;
+
+    /// Run post
+    fn post_bundle<Db: Database + DatabaseCommit>(
+        &mut self,
+        trevm: &EvmNeedsTx<'_, Ext, Db>,
+    ) -> Result<(), Self::Error<Db>>;
+}

--- a/src/driver/bundle.rs
+++ b/src/driver/bundle.rs
@@ -12,7 +12,7 @@ pub trait BundleDriver<Ext> {
     type Error<Db: Database>: std::error::Error + From<EVMError<Db::Error>>;
 
     /// Run the transactions contained in the bundle.
-    fn run_txns<'a, Db: Database + DatabaseCommit>(
+    fn run_bundle<'a, Db: Database + DatabaseCommit>(
         &mut self,
         trevm: EvmNeedsTx<'a, Ext, Db>,
     ) -> DriveBundleResult<'a, Ext, Db, Self>;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,5 +1,8 @@
 mod block;
 pub use block::{BlockDriver, DriveBlockResult, RunTxResult};
 
+mod bundle;
+pub use bundle::{BundleDriver, DriveBundleResult};
+
 mod chain;
 pub use chain::{ChainDriver, DriveChainResult};

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,5 +1,5 @@
 mod alloy;
-pub use alloy::BundleError;
+pub use alloy::{BundleError, BundleSimulator};
 
 mod block;
 pub use block::{BlockDriver, DriveBlockResult, RunTxResult};

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,4 +1,5 @@
 mod alloy;
+pub use alloy::BundleError;
 
 mod block;
 pub use block::{BlockDriver, DriveBlockResult, RunTxResult};

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,5 +1,5 @@
 mod alloy;
-pub use alloy::{BundleError, BundleSimulator};
+pub use alloy::{BundleError, BundleProcessor};
 
 mod block;
 pub use block::{BlockDriver, DriveBlockResult, RunTxResult};

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,3 +1,5 @@
+mod alloy;
+
 mod block;
 pub use block::{BlockDriver, DriveBlockResult, RunTxResult};
 

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -820,7 +820,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
         F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         NewState: HasBlock,
     {
-        let previous = std::mem::take(self.inner.block_mut());
+        let previous = self.inner.block_mut().clone();
         b.fill_block_env(self.inner.block_mut());
         let mut this = f(self);
         *this.inner.block_mut() = previous;
@@ -838,7 +838,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
         B: Block,
         NewState: HasBlock,
     {
-        let previous = std::mem::take(self.inner.block_mut());
+        let previous = self.inner.block_mut().clone();
         b.fill_block_env(self.inner.block_mut());
         match f(self) {
             Ok(mut evm) => {

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -517,10 +517,10 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasCfg> Trevm<'a, Ext, 
     /// Run a function with the provided configuration, then restore the
     /// previous configuration. This will not affect the block and tx, if those
     /// have been filled.
-    pub fn with_cfg<F, C, NewState>(mut self, f: F, cfg: &C) -> Trevm<'a, Ext, Db, NewState>
+    pub fn with_cfg<C, F, NewState>(mut self, cfg: &C, f: F) -> Trevm<'a, Ext, Db, NewState>
     where
-        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         C: Cfg,
+        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         NewState: HasCfg,
     {
         let previous = std::mem::take(self.inner.cfg_mut());
@@ -814,10 +814,10 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmNeedsBlock<'a, Ext, Db> {
 
 impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext, Db, TrevmState> {
     /// Run a function with the provided block, then restore the previous block.
-    pub fn with_block<F, B, NewState>(mut self, b: &B, f: F) -> Trevm<'a, Ext, Db, NewState>
+    pub fn with_block<B, F, NewState>(mut self, b: &B, f: F) -> Trevm<'a, Ext, Db, NewState>
     where
-        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         B: Block,
+        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         NewState: HasBlock,
     {
         let previous = std::mem::take(self.inner.block_mut());
@@ -828,7 +828,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
     }
 
     /// Run a fallible function with the provided block, then restore the previous block.
-    pub fn try_with_block<F, B, NewState, E>(
+    pub fn try_with_block<B, F, NewState, E>(
         mut self,
         b: &B,
         f: F,
@@ -920,10 +920,10 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmNeedsTx<'a, Ext, Db> {
 impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasTx> Trevm<'a, Ext, Db, TrevmState> {
     /// Run a function with the provided transaction, then restore the previous
     /// transaction.
-    pub fn with_tx<F, T, NewState>(mut self, f: F, t: &T) -> Trevm<'a, Ext, Db, NewState>
+    pub fn with_tx<T, F, NewState>(mut self, t: &T, f: F) -> Trevm<'a, Ext, Db, NewState>
     where
-        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         T: Tx,
+        F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         NewState: HasTx,
     {
         let previous = std::mem::take(self.inner.tx_mut());

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -866,7 +866,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmNeedsTx<'a, Ext, Db> {
     where
         D: BundleDriver<Ext>,
     {
-        let trevm = driver.run_txns(self)?;
+        let trevm = driver.run_bundle(self)?;
 
         match driver.post_bundle(&trevm) {
             Ok(_) => Ok(trevm),

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -814,7 +814,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmNeedsBlock<'a, Ext, Db> {
 
 impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext, Db, TrevmState> {
     /// Run a function with the provided block, then restore the previous block.
-    pub fn with_block<F, B, NewState>(mut self, f: F, b: &B) -> Trevm<'a, Ext, Db, NewState>
+    pub fn with_block<F, B, NewState>(mut self, b: &B, f: F) -> Trevm<'a, Ext, Db, NewState>
     where
         F: FnOnce(Self) -> Trevm<'a, Ext, Db, NewState>,
         B: Block,
@@ -830,8 +830,8 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
     /// Run a fallible function with the provided block, then restore the previous block.
     pub fn try_with_block<F, B, NewState, E>(
         mut self,
-        f: F,
         b: &B,
+        f: F,
     ) -> Result<Trevm<'a, Ext, Db, NewState>, EvmErrored<'a, Ext, Db, E>>
     where
         F: FnOnce(Self) -> Result<Trevm<'a, Ext, Db, NewState>, EvmErrored<'a, Ext, Db, E>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,8 @@ pub use fill::{Block, Cfg, NoopBlock, NoopCfg, Tx};
 mod lifecycle;
 pub use lifecycle::{ethereum_receipt, BlockOutput, PostTx, PostflightResult};
 
+mod macros;
+
 mod states;
 pub(crate) use states::sealed::*;
 pub use states::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,8 +364,8 @@
 
 mod driver;
 pub use driver::{
-    BlockDriver, BundleDriver, BundleError, BundleSimulator, ChainDriver, DriveBlockResult, DriveBundleResult,
-    DriveChainResult, RunTxResult,
+    BlockDriver, BundleDriver, BundleError, BundleSimulator, ChainDriver, DriveBlockResult,
+    DriveBundleResult, DriveChainResult, RunTxResult,
 };
 
 mod evm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@
 
 mod driver;
 pub use driver::{
-    BlockDriver, BundleDriver, BundleError, ChainDriver, DriveBlockResult, DriveBundleResult,
+    BlockDriver, BundleDriver, BundleError, BundleSimulator, ChainDriver, DriveBlockResult, DriveBundleResult,
     DriveChainResult, RunTxResult,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,10 @@
 #![warn(missing_docs, missing_copy_implementations, missing_debug_implementations)]
 
 mod driver;
-pub use driver::{BlockDriver, ChainDriver, DriveBlockResult, DriveChainResult, RunTxResult};
+pub use driver::{
+    BlockDriver, BundleDriver, ChainDriver, DriveBlockResult, DriveBundleResult, DriveChainResult,
+    RunTxResult,
+};
 
 mod evm;
 pub use evm::Trevm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@
 
 mod driver;
 pub use driver::{
-    BlockDriver, BundleDriver, BundleError, BundleSimulator, ChainDriver, DriveBlockResult,
+    BlockDriver, BundleDriver, BundleError, BundleProcessor, ChainDriver, DriveBlockResult,
     DriveBundleResult, DriveChainResult, RunTxResult,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,8 +364,8 @@
 
 mod driver;
 pub use driver::{
-    BlockDriver, BundleDriver, ChainDriver, DriveBlockResult, DriveBundleResult, DriveChainResult,
-    RunTxResult,
+    BlockDriver, BundleDriver, BundleError, ChainDriver, DriveBlockResult, DriveBundleResult,
+    DriveChainResult, RunTxResult,
 };
 
 mod evm;
@@ -383,8 +383,8 @@ pub use lifecycle::{ethereum_receipt, BlockOutput, PostTx, PostflightResult};
 mod states;
 pub(crate) use states::sealed::*;
 pub use states::{
-    EvmBlockDriverErrored, EvmChainDriverErrored, EvmErrored, EvmNeedsBlock, EvmNeedsCfg,
-    EvmNeedsTx, EvmReady, EvmTransacted,
+    EvmBlockDriverErrored, EvmBundleDriverErrored, EvmChainDriverErrored, EvmErrored,
+    EvmNeedsBlock, EvmNeedsCfg, EvmNeedsTx, EvmReady, EvmTransacted,
 };
 
 pub mod system;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,28 @@
+/// Unwraps a Result, returning the value if successful, or returning an errored `Trevm` if not.
+#[macro_export]
+macro_rules! unwrap_or_trevm_err {
+    ($e:expr, $trevm:expr) => {
+        match $e {
+            Ok(val) => val,
+            Err(e) => return Err($trevm.errored(e.into())),
+        }
+    };
+}
+
+/// Executes a condition, returning an errored `Trevm` if not successful.
+#[macro_export]
+macro_rules! trevm_ensure {
+    ($cond:expr, $trevm:expr, $err:expr) => {
+        if !$cond {
+            trevm_bail!($trevm, $err);
+        }
+    };
+}
+
+/// Returns an errored `Trevm` with the provided error.
+#[macro_export]
+macro_rules! trevm_bail {
+    ($trevm:expr, $err:expr) => {
+        return Err($trevm.errored($err))
+    };
+}

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,4 +1,4 @@
-use crate::{BlockDriver, ChainDriver, Trevm};
+use crate::{driver::BundleDriver, BlockDriver, ChainDriver, Trevm};
 use revm::{primitives::EVMError, Database};
 use sealed::*;
 
@@ -63,6 +63,12 @@ pub type EvmBlockDriverErrored<'a, Ext, Db, T> =
 /// This is an [`EvmErrored`] parameterized with the driver's error type.
 pub type EvmChainDriverErrored<'a, Ext, Db, T> =
     EvmErrored<'a, Ext, Db, <T as ChainDriver<Ext>>::Error<Db>>;
+
+/// A [`Trevm`] that encountered an error during [`BundleDriver`] execution.
+///
+/// This is an [`EvmErrored`] parameterized with the driver's error type.
+pub(crate) type EvmBundleDriverErrored<'a, Ext, Db, T> =
+    EvmErrored<'a, Ext, Db, <T as BundleDriver<Ext>>::Error<Db>>;
 
 #[allow(unnameable_types, dead_code, unreachable_pub)]
 pub(crate) mod sealed {

--- a/src/states.rs
+++ b/src/states.rs
@@ -148,6 +148,7 @@ pub(crate) mod sealed {
 /// - [`EvmErrored`]
 /// - [`EvmBlockDriverErrored`]
 /// - [`EvmChainDriverErrored`]
+/// - [`EvmBundleDriverErrored`]
 ///
 /// ## Basic usage:
 ///
@@ -266,6 +267,12 @@ macro_rules! trevm_aliases {
             ///
             /// This is an [`EvmErrored`] parameterized with the driver's error type.
             pub type EvmChainDriverErrored<'a, T> = $crate::EvmChainDriverErrored<'a, $ext, $db, T>;
+
+            /// A [`Trevm`] that encountered an error during [`BundleDriver`] execution.
+            ///
+            /// This is an [`EvmErrored`] parameterized with the driver's error type.
+            pub type EvmBundleDriverErrored<'a, T> =
+                $crate::EvmBundleDriverErrored<'a, $ext, $db, T>;
         }
     };
 
@@ -338,6 +345,12 @@ macro_rules! trevm_aliases {
             /// This is an [`EvmErrored`] parameterized with the driver's error type.
             pub type EvmChainDriverErrored<'a, T> =
                 $crate::EvmChainDriverErrored<'static, $ext, $db, T>;
+
+            /// A [`Trevm`] that encountered an error during [`BundleDriver`] execution.
+            ///
+            /// This is an [`EvmErrored`] parameterized with the driver's error type.
+            pub type EvmBundleDriverErrored<'a, T> =
+                $crate::EvmBundleDriverErrored<'static, $ext, $db, T>;
         }
     };
 }

--- a/src/states.rs
+++ b/src/states.rs
@@ -67,7 +67,7 @@ pub type EvmChainDriverErrored<'a, Ext, Db, T> =
 /// A [`Trevm`] that encountered an error during [`BundleDriver`] execution.
 ///
 /// This is an [`EvmErrored`] parameterized with the driver's error type.
-pub(crate) type EvmBundleDriverErrored<'a, Ext, Db, T> =
+pub type EvmBundleDriverErrored<'a, Ext, Db, T> =
     EvmErrored<'a, Ext, Db, <T as BundleDriver<Ext>>::Error<Db>>;
 
 #[allow(unnameable_types, dead_code, unreachable_pub)]


### PR DESCRIPTION
Adds a simple `BundleDriver` trait, which can drive bundles to completion.

Conceptually, it starts from an `EvmNeedsTx` state, and ends there. This means that this driver simply allows to run a group of transactions, while applying post-multi-tx logic after. It *does not* open or close blocks. This also allows us to run several bundles, one after another.

This `BundleDriver` trait is then composed with a `BlockProcessor` struct, which then takes charge of implementing a `BundleDriver` for a combination of a bundle type, and a response type. This allows us, for example, to quickly grab bundles that conform to [flashbots bundles](https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-mev/src/eth_calls.rs#L13-L96), simulate them, and return a properly calculated & formatted response. Vanilla impls for `EthCallBundle` & `EthSendBundle` are also provided which do not accumulate results.

A few macros were also added, mirroring eyre macros:
- `unwrap_or_trevm_err!`: Unwraps a Result, returning the value if successful, or returning an errored `Trevm` if not.
-  `trevm_ensure!`: Executes a condition, returning an errored `Trevm` if not successful.
-  `trevm_bail!`: Returns an errored `Trevm` with the provided error.

And lastly, `try_with_*` fns were added to have fallible `with_*` functions. The behavior of these was modified as well to use `clone` instead of `mem::take` to avoid having default values, which might be unexpected for the user.

- [x] Driver trait
- [x] sample alloy-rpc-types-mev implementation

fixes ENG-311