### PR TITLE
fix: remove Commit bound on finish as it is provided by State

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.79.0"
 edition = "2021"
 authors = ["init4"]

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -892,7 +892,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmNeedsBlock<'a, Ext, State<Db>> {
     /// See [`State::merge_transitions`] and [`State::take_bundle`].
     pub fn finish(self) -> BundleState
     where
-        Db: Database + DatabaseCommit,
+        Db: Database,
     {
         let Self { inner: mut evm, .. } = self;
 


### PR DESCRIPTION
bounding the inner DB prevents usage with (e.g.) reth's stateproviderbox and stateproviderdatabase shims