### PR TITLE
refactor: add Send and Sync as supertraits of fillers

### DIFF
--- a/src/fill/alloy.rs
+++ b/src/fill/alloy.rs
@@ -272,7 +272,7 @@ impl Block for alloy::rpc::types::eth::Header {
     }
 }
 
-impl<T> Block for alloy::rpc::types::eth::Block<T> {
+impl<T: Send + Sync> Block for alloy::rpc::types::eth::Block<T> {
     fn fill_block_env(&self, block_env: &mut revm::primitives::BlockEnv) {
         self.header.fill_block_env(block_env);
     }

--- a/src/fill/traits.rs
+++ b/src/fill/traits.rs
@@ -4,7 +4,7 @@ use revm::{
 };
 
 /// Types that can fill the EVM transaction environment [`TxEnv`].
-pub trait Tx {
+pub trait Tx: Send + Sync {
     /// Fill the transaction environment.
     ///
     /// ## Note:
@@ -23,7 +23,7 @@ pub trait Tx {
     }
 }
 /// Types that can fill the EVM block environment [`BlockEnv`].
-pub trait Block {
+pub trait Block: Send + Sync {
     /// Fill the block environment.
     ///
     /// ## Note:
@@ -64,7 +64,7 @@ pub trait Block {
 /// - `disable_beneficiary_reward` - gated by `optional_beneficiary_reward`
 ///
 /// Cfg fillers should consider these feature gates when implementing the trait.
-pub trait Cfg {
+pub trait Cfg: Send + Sync {
     /// Fill the configuration environment.
     fn fill_cfg_env(&self, cfg_env: &mut CfgEnv);
 


### PR DESCRIPTION
these are supposed to be dumb data-carriers. there isn't a use case for ones containing RCs, thread locals, etc, as all data is efficiently copyable, so we bound them here to prevent bounds from leaking into codebases using trevm