### PR TITLE
`ConcurrentState`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ alloy = { version = "=0.5.4", default-features = false, features = ["consensus",
 revm = { version = "18.0.0", default-features = false }
 
 zenith-types = { version = "0.10", optional = true }
-dashmap = "6.1.0"
+
+dashmap = { version = "6.1.0", optional = true }
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", default-features = false }
@@ -57,6 +58,7 @@ tokio = { version = "1.39", features = ["macros", "rt-multi-thread"] }
 [features]
 default = [
     "std",
+    "concurrent-db",
     "revm/std",
     "revm/c-kzg",
     "revm/blst",
@@ -65,6 +67,8 @@ default = [
 ]
 
 std = ["revm/std", "alloy/std", "alloy-rlp/std", "alloy-primitives/std", "alloy-sol-types/std", "dep:zenith-types"]
+
+concurrent-db = ["std", "dep:dashmap"]
 
 test-utils = ["revm/test-utils", "revm/std", "revm/serde-json", "revm/alloydb"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ alloy = { version = "=0.5.4", default-features = false, features = ["consensus",
 revm = { version = "18.0.0", default-features = false }
 
 zenith-types = { version = "0.10", optional = true }
+dashmap = "6.1.0"
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", default-features = false }

--- a/src/db/builder.rs
+++ b/src/db/builder.rs
@@ -11,7 +11,7 @@ use revm::{
 };
 use std::collections::BTreeMap;
 
-use super::{ConcurrentCacheState, ConcurrentStateCache};
+use super::{ConcurrentCacheState, ConcurrentStateInfo};
 
 /// Allows building of State and initializing it with different options.
 #[derive(Clone, Debug)]
@@ -150,7 +150,7 @@ impl<DB: DatabaseRef> ConcurrentStateBuilder<DB> {
         };
         ConcurrentState::new(
             self.database,
-            ConcurrentStateCache {
+            ConcurrentStateInfo {
                 cache: self
                     .with_cache_prestate
                     .unwrap_or_else(|| ConcurrentCacheState::new(self.with_state_clear)),

--- a/src/db/builder.rs
+++ b/src/db/builder.rs
@@ -1,0 +1,189 @@
+use crate::db::ConcurrentState;
+use revm::{
+    db::{
+        states::{state::DBBox, BundleState, TransitionState},
+        EmptyDB,
+    },
+    primitives::{
+        db::{Database, DatabaseRef, WrapDatabaseRef},
+        B256,
+    },
+};
+use std::collections::BTreeMap;
+
+use super::{ConcurrentCacheState, ConcurrentStateCache};
+
+/// Allows building of State and initializing it with different options.
+#[derive(Clone, Debug)]
+pub struct ConcurrentStateBuilder<DB> {
+    /// Database that we use to fetch data from.
+    database: DB,
+    /// Enabled state clear flag that is introduced in Spurious Dragon hardfork.
+    /// Default is true as spurious dragon happened long time ago.
+    with_state_clear: bool,
+    /// if there is prestate that we want to use.
+    /// This would mean that we have additional state layer between evm and disk/database.
+    with_bundle_prestate: Option<BundleState>,
+    /// This will initialize cache to this state.
+    with_cache_prestate: Option<ConcurrentCacheState>,
+    /// Do we want to create reverts and update bundle state.
+    /// Default is false.
+    with_bundle_update: bool,
+    /// Do we want to merge transitions in background.
+    /// This will allows evm to continue executing.
+    /// Default is false.
+    with_background_transition_merge: bool,
+    /// If we want to set different block hashes
+    with_block_hashes: BTreeMap<u64, B256>,
+}
+
+impl ConcurrentStateBuilder<EmptyDB> {
+    /// Create a new builder with an empty database.
+    ///
+    /// If you want to instantiate it with a specific database, use
+    /// [`new_with_database`](Self::new_with_database).
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<DB: DatabaseRef + Default> Default for ConcurrentStateBuilder<DB> {
+    fn default() -> Self {
+        Self::new_with_database(DB::default())
+    }
+}
+
+impl<DB: DatabaseRef> ConcurrentStateBuilder<DB> {
+    /// Create a new builder with the given database.
+    pub const fn new_with_database(database: DB) -> Self {
+        Self {
+            database,
+            with_state_clear: true,
+            with_cache_prestate: None,
+            with_bundle_prestate: None,
+            with_bundle_update: false,
+            with_background_transition_merge: false,
+            with_block_hashes: BTreeMap::new(),
+        }
+    }
+
+    /// Set the database.
+    pub fn with_database<ODB: Database>(self, database: ODB) -> ConcurrentStateBuilder<ODB> {
+        // cast to the different database,
+        // Note that we return different type depending of the database NewDBError.
+        ConcurrentStateBuilder {
+            with_state_clear: self.with_state_clear,
+            database,
+            with_cache_prestate: self.with_cache_prestate,
+            with_bundle_prestate: self.with_bundle_prestate,
+            with_bundle_update: self.with_bundle_update,
+            with_background_transition_merge: self.with_background_transition_merge,
+            with_block_hashes: self.with_block_hashes,
+        }
+    }
+
+    /// Takes [DatabaseRef] and wraps it with [WrapDatabaseRef].
+    pub fn with_database_ref<ODB: DatabaseRef>(
+        self,
+        database: ODB,
+    ) -> ConcurrentStateBuilder<WrapDatabaseRef<ODB>> {
+        self.with_database(WrapDatabaseRef(database))
+    }
+
+    /// With boxed version of database.
+    pub fn with_database_boxed<Error>(
+        self,
+        database: DBBox<'_, Error>,
+    ) -> ConcurrentStateBuilder<DBBox<'_, Error>> {
+        self.with_database(database)
+    }
+
+    /// By default state clear flag is enabled but for initial sync on mainnet
+    /// we want to disable it so proper consensus changes are in place.
+    pub fn without_state_clear(self) -> Self {
+        Self { with_state_clear: false, ..self }
+    }
+
+    /// Allows setting prestate that is going to be used for execution.
+    /// This bundle state will act as additional layer of cache.
+    /// and State after not finding data inside StateCache will try to find it inside BundleState.
+    ///
+    /// On update Bundle state will be changed and updated.
+    pub fn with_bundle_prestate(self, bundle: BundleState) -> Self {
+        Self { with_bundle_prestate: Some(bundle), ..self }
+    }
+
+    /// Make transitions and update bundle state.
+    ///
+    /// This is needed option if we want to create reverts
+    /// and getting output of changed states.
+    pub fn with_bundle_update(self) -> Self {
+        Self { with_bundle_update: true, ..self }
+    }
+
+    /// It will use different cache for the state. If set, it will ignore bundle prestate.
+    /// and will ignore `without_state_clear` flag as cache contains its own state_clear flag.
+    ///
+    /// This is useful for testing.
+    pub fn with_cached_prestate(self, cache: impl Into<ConcurrentCacheState>) -> Self {
+        Self { with_cache_prestate: Some(cache.into()), ..self }
+    }
+
+    /// Starts the thread that will take transitions and do merge to the bundle state
+    /// in the background.
+    pub fn with_background_transition_merge(self) -> Self {
+        Self { with_background_transition_merge: true, ..self }
+    }
+
+    /// Add block hashes to the state.
+    pub fn with_block_hashes(self, block_hashes: BTreeMap<u64, B256>) -> Self {
+        Self { with_block_hashes: block_hashes, ..self }
+    }
+
+    /// Build the concurrent state.
+    pub fn build(mut self) -> ConcurrentState<DB> {
+        let use_preloaded_bundle = if self.with_cache_prestate.is_some() {
+            self.with_bundle_prestate = None;
+            false
+        } else {
+            self.with_bundle_prestate.is_some()
+        };
+        ConcurrentState::new(
+            self.database,
+            ConcurrentStateCache {
+                cache: self
+                    .with_cache_prestate
+                    .unwrap_or_else(|| ConcurrentCacheState::new(self.with_state_clear)),
+                transition_state: self.with_bundle_update.then(TransitionState::default),
+                bundle_state: self.with_bundle_prestate.unwrap_or_default(),
+                use_preloaded_bundle,
+                block_hashes: self.with_block_hashes.into(),
+            },
+        )
+    }
+}
+
+// Some code above and documentation is adapted from the revm crate, and is
+// reproduced here under the terms of the MIT license.
+//
+// MIT License
+//
+// Copyright (c) 2021-2024 draganrakita
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.

--- a/src/db/cache_state.rs
+++ b/src/db/cache_state.rs
@@ -9,6 +9,8 @@ use revm::{
 };
 
 /// A concurrent version of [`revm::db::CacheState`].
+///
+/// Most of the code for this has been reproduced from revm.
 #[derive(Debug)]
 pub struct ConcurrentCacheState {
     /// Block state account with account state.

--- a/src/db/cache_state.rs
+++ b/src/db/cache_state.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::AtomicBool;
+//! The majority of this code has been reproduced from revm.
 
 use alloy_primitives::{Address, B256};
 use dashmap::DashMap;
@@ -19,7 +19,7 @@ pub struct ConcurrentCacheState {
     // TODO add bytecode counter for number of bytecodes added/removed.
     pub contracts: DashMap<B256, Bytecode>,
     /// Has EIP-161 state clear enabled (Spurious Dragon hardfork).
-    pub has_state_clear: AtomicBool,
+    pub has_state_clear: bool,
 }
 
 impl Default for ConcurrentCacheState {
@@ -39,8 +39,8 @@ impl ConcurrentCacheState {
     }
 
     /// Set state clear flag. EIP-161.
-    pub fn set_state_clear_flag(&self, has_state_clear: bool) {
-        self.has_state_clear.store(has_state_clear, core::sync::atomic::Ordering::Relaxed);
+    pub fn set_state_clear_flag(&mut self, has_state_clear: bool) {
+        self.has_state_clear = has_state_clear;
     }
 
     /// Insert not existing account.
@@ -129,7 +129,7 @@ impl ConcurrentCacheState {
         // And when empty account is touched it needs to be removed from database.
         // EIP-161 state clear
         if is_empty {
-            if self.has_state_clear.load(core::sync::atomic::Ordering::Relaxed) {
+            if self.has_state_clear {
                 // touch empty account.
                 this_account.touch_empty_eip161()
             } else {

--- a/src/db/cache_state.rs
+++ b/src/db/cache_state.rs
@@ -1,0 +1,167 @@
+use core::sync::atomic::AtomicBool;
+
+use alloy_primitives::{Address, B256};
+use dashmap::DashMap;
+use revm::{
+    db::states::{plain_account::PlainStorage, CacheAccount},
+    primitives::{Account, AccountInfo, Bytecode, EvmState},
+    TransitionAccount,
+};
+
+/// A concurrent version of [`revm::db::CacheState`].
+#[derive(Debug)]
+pub struct ConcurrentCacheState {
+    /// Block state account with account state.
+    pub accounts: DashMap<Address, CacheAccount>,
+    /// Created contracts.
+    // TODO add bytecode counter for number of bytecodes added/removed.
+    pub contracts: DashMap<B256, Bytecode>,
+    /// Has EIP-161 state clear enabled (Spurious Dragon hardfork).
+    pub has_state_clear: AtomicBool,
+}
+
+impl Default for ConcurrentCacheState {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl ConcurrentCacheState {
+    /// New default state.
+    pub fn new(has_state_clear: bool) -> Self {
+        Self {
+            accounts: DashMap::default(),
+            contracts: DashMap::default(),
+            has_state_clear: has_state_clear.into(),
+        }
+    }
+
+    /// Set state clear flag. EIP-161.
+    pub fn set_state_clear_flag(&self, has_state_clear: bool) {
+        self.has_state_clear.store(has_state_clear, core::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Insert not existing account.
+    pub fn insert_not_existing(&self, address: Address) {
+        self.accounts.insert(address, CacheAccount::new_loaded_not_existing());
+    }
+
+    /// Insert Loaded (Or LoadedEmptyEip161 if account is empty) account.
+    pub fn insert_account(&self, address: Address, info: AccountInfo) {
+        let account = if !info.is_empty() {
+            CacheAccount::new_loaded(info, PlainStorage::default())
+        } else {
+            CacheAccount::new_loaded_empty_eip161(PlainStorage::default())
+        };
+        self.accounts.insert(address, account);
+    }
+
+    /// Similar to `insert_account` but with storage.
+    pub fn insert_account_with_storage(
+        &self,
+        address: Address,
+        info: AccountInfo,
+        storage: PlainStorage,
+    ) {
+        let account = if !info.is_empty() {
+            CacheAccount::new_loaded(info, storage)
+        } else {
+            CacheAccount::new_loaded_empty_eip161(storage)
+        };
+        self.accounts.insert(address, account);
+    }
+
+    /// Apply output of revm execution and create account transitions that are used to build BundleState.
+    pub fn apply_evm_state(&self, evm_state: EvmState) -> Vec<(Address, TransitionAccount)> {
+        let mut transitions = Vec::with_capacity(evm_state.len());
+        for (address, account) in evm_state {
+            if let Some(transition) = self.apply_account_state(address, account) {
+                transitions.push((address, transition));
+            }
+        }
+        transitions
+    }
+
+    /// Apply updated account state to the cached account.
+    /// Returns account transition if applicable.
+    fn apply_account_state(&self, address: Address, account: Account) -> Option<TransitionAccount> {
+        // not touched account are never changed.
+        if !account.is_touched() {
+            return None;
+        }
+
+        let mut this_account =
+            self.accounts.get_mut(&address).expect("All accounts should be present inside cache");
+
+        // If it is marked as selfdestructed inside revm
+        // we need to changed state to destroyed.
+        if account.is_selfdestructed() {
+            return this_account.selfdestruct();
+        }
+
+        let is_created = account.is_created();
+        let is_empty = account.is_empty();
+
+        // transform evm storage to storage with previous value.
+        let changed_storage = account
+            .storage
+            .into_iter()
+            .filter(|(_, slot)| slot.is_changed())
+            .map(|(key, slot)| (key, slot.into()))
+            .collect();
+
+        // Note: it can happen that created contract get selfdestructed in same block
+        // that is why is_created is checked after selfdestructed
+        //
+        // Note: Create2 opcode (Petersburg) was after state clear EIP (Spurious Dragon)
+        //
+        // Note: It is possibility to create KECCAK_EMPTY contract with some storage
+        // by just setting storage inside CRATE constructor. Overlap of those contracts
+        // is not possible because CREATE2 is introduced later.
+        if is_created {
+            return Some(this_account.newly_created(account.info, changed_storage));
+        }
+
+        // Account is touched, but not selfdestructed or newly created.
+        // Account can be touched and not changed.
+        // And when empty account is touched it needs to be removed from database.
+        // EIP-161 state clear
+        if is_empty {
+            if self.has_state_clear.load(core::sync::atomic::Ordering::Relaxed) {
+                // touch empty account.
+                this_account.touch_empty_eip161()
+            } else {
+                // if account is empty and state clear is not enabled we should save
+                // empty account.
+                this_account.touch_create_pre_eip161(changed_storage)
+            }
+        } else {
+            Some(this_account.change(account.info, changed_storage))
+        }
+    }
+}
+
+// Some code above and documentation is adapted from the revm crate, and is
+// reproduced here under the terms of the MIT license.
+//
+// MIT License
+//
+// Copyright (c) 2021-2024 draganrakita
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,5 @@
+mod sync_state;
+pub use sync_state::{ConcurrentState, StateInfo};
+
+mod cache_state;
+pub use cache_state::ConcurrentCacheState;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,7 +5,7 @@ mod cache_state;
 pub use cache_state::ConcurrentCacheState;
 
 mod sync_state;
-pub use sync_state::{ConcurrentState, ConcurrentStateCache};
+pub use sync_state::{ConcurrentState, ConcurrentStateInfo};
 
 use crate::{EvmNeedsBlock, Trevm};
 use revm::{

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,8 +1,11 @@
-mod sync_state;
-pub use sync_state::{ConcurrentState, ConcurrentStateCache};
+mod builder;
+pub use builder::ConcurrentStateBuilder;
 
 mod cache_state;
 pub use cache_state::ConcurrentCacheState;
+
+mod sync_state;
+pub use sync_state::{ConcurrentState, ConcurrentStateCache};
 
 use crate::{EvmNeedsBlock, Trevm};
 use revm::{

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,3 +3,34 @@ pub use sync_state::{ConcurrentState, StateInfo};
 
 mod cache_state;
 pub use cache_state::ConcurrentCacheState;
+
+use crate::{EvmNeedsBlock, Trevm};
+use revm::{
+    db::{states::bundle_state::BundleRetention, BundleState},
+    DatabaseRef,
+};
+
+impl<Ext, Db: DatabaseRef, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, TrevmState> {
+    /// Set the [EIP-161] state clear flag, activated in the Spurious Dragon
+    /// hardfork.
+    pub fn set_state_clear_flag(&mut self, flag: bool) {
+        self.inner.db_mut().set_state_clear_flag(flag)
+    }
+}
+
+impl<'a, Ext, Db: DatabaseRef> EvmNeedsBlock<'a, Ext, ConcurrentState<Db>> {
+    /// Finish execution and return the outputs.
+    ///
+    /// ## Panics
+    ///
+    /// If the State has not been built with StateBuilder::with_bundle_update.
+    ///
+    /// See [`State::merge_transitions`] and [`State::take_bundle`].
+    pub fn finish(self) -> BundleState {
+        let Self { inner: mut evm, .. } = self;
+        evm.db_mut().merge_transitions(BundleRetention::Reverts);
+        let bundle = evm.db_mut().take_bundle();
+
+        bundle
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,7 +18,7 @@ impl<Ext, Db: DatabaseRef, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, Trevm
     }
 }
 
-impl<'a, Ext, Db: DatabaseRef> EvmNeedsBlock<'a, Ext, ConcurrentState<Db>> {
+impl<Ext, Db: DatabaseRef> EvmNeedsBlock<'_, Ext, ConcurrentState<Db>> {
     /// Finish execution and return the outputs.
     ///
     /// ## Panics

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 mod builder;
+
 pub use builder::ConcurrentStateBuilder;
 
 mod cache_state;
@@ -13,7 +14,7 @@ use revm::{
     DatabaseRef,
 };
 
-impl<Ext, Db: DatabaseRef, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, TrevmState> {
+impl<Ext, Db: DatabaseRef + Sync, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, TrevmState> {
     /// Set the [EIP-161] state clear flag, activated in the Spurious Dragon
     /// hardfork.
     ///
@@ -23,7 +24,7 @@ impl<Ext, Db: DatabaseRef, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, Trevm
     }
 }
 
-impl<Ext, Db: DatabaseRef> EvmNeedsBlock<'_, Ext, ConcurrentState<Db>> {
+impl<Ext, Db: DatabaseRef + Sync> EvmNeedsBlock<'_, Ext, ConcurrentState<Db>> {
     /// Finish execution and return the outputs.
     ///
     /// If the State has not been built with

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -7,7 +7,7 @@ use revm::{
         BundleState,
     },
     primitives::{Account, AccountInfo, Bytecode},
-    DatabaseCommit, DatabaseRef, TransitionAccount, TransitionState,
+    Database, DatabaseCommit, DatabaseRef, TransitionAccount, TransitionState,
 };
 use std::{
     collections::{hash_map, BTreeMap},
@@ -297,6 +297,26 @@ impl<DB: DatabaseRef> DatabaseCommit for ConcurrentState<DB> {
     fn commit(&mut self, evm_state: revm::primitives::HashMap<Address, Account>) {
         let transitions = self.info.cache.apply_evm_state(evm_state);
         self.apply_transition(transitions);
+    }
+}
+
+impl<Db: DatabaseRef> Database for ConcurrentState<Db> {
+    type Error = <Self as DatabaseRef>::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.basic_ref(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.code_by_hash_ref(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.storage_ref(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.block_hash_ref(number)
     }
 }
 

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -19,7 +19,7 @@ use std::{collections::hash_map, sync::RwLock};
 pub struct ConcurrentState<Db> {
     database: Db,
     /// Non-DB state cache and transition information.
-    pub info: ConcurrentStateCache,
+    pub info: ConcurrentStateInfo,
 }
 
 impl<Db> From<State<Db>> for ConcurrentState<Db>
@@ -29,7 +29,7 @@ where
     fn from(value: State<Db>) -> Self {
         Self {
             database: value.database,
-            info: ConcurrentStateCache {
+            info: ConcurrentStateInfo {
                 cache: value.cache.into(),
                 transition_state: value.transition_state,
                 bundle_state: value.bundle_state,
@@ -42,7 +42,7 @@ where
 
 /// Non-DB contents of [`ConcurrentState`]
 #[derive(Debug, Default)]
-pub struct ConcurrentStateCache {
+pub struct ConcurrentStateInfo {
     /// Cached state contains both changed from evm execution and cached/loaded
     /// account/storages from database. This allows us to have only one layer
     /// of cache where we can fetch data. Additionally we can introduce some
@@ -75,12 +75,12 @@ pub struct ConcurrentStateCache {
 impl<Db: DatabaseRef> ConcurrentState<Db> {
     /// Create a new [`ConcurrentState`] with the given database and cache
     /// state.
-    pub const fn new(database: Db, info: ConcurrentStateCache) -> Self {
+    pub const fn new(database: Db, info: ConcurrentStateInfo) -> Self {
         Self { database, info }
     }
 
     /// Deconstruct the [`ConcurrentState`] into its parts.
-    pub fn into_parts(self) -> (Db, ConcurrentStateCache) {
+    pub fn into_parts(self) -> (Db, ConcurrentStateInfo) {
         (self.database, self.info)
     }
 

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -1,0 +1,326 @@
+use crate::db::ConcurrentCacheState;
+use alloy_primitives::{Address, B256, U256};
+use dashmap::mapref::one::RefMut;
+use revm::{
+    db::{
+        states::{bundle_state::BundleRetention, plain_account::PlainStorage, CacheAccount},
+        BundleState,
+    },
+    primitives::{Account, AccountInfo, Bytecode},
+    DatabaseCommit, DatabaseRef, TransitionAccount, TransitionState,
+};
+use std::{
+    collections::{hash_map, BTreeMap},
+    sync::RwLock,
+};
+
+/// State of blockchain.
+///
+/// A version of [`revm::db::State`] that can be shared between threads.
+#[derive(Debug)]
+pub struct ConcurrentState<Db> {
+    database: Db,
+    /// Non-DB state cache and transition information.
+    pub info: StateInfo,
+}
+
+/// Non-DB contents of [`ConcurrentState`]
+#[derive(Debug, Default)]
+pub struct StateInfo {
+    /// Cached state contains both changed from evm execution and cached/loaded
+    /// account/storages from database. This allows us to have only one layer
+    /// of cache where we can fetch data. Additionally we can introduce some
+    /// preloading of data from database.
+    pub cache: ConcurrentCacheState,
+    /// Block state, it aggregates transactions transitions into one state.
+    ///
+    /// Build reverts and state that gets applied to the state.
+    pub transition_state: Option<TransitionState>,
+    /// After block is finishes we merge those changes inside bundle.
+    /// Bundle is used to update database and create changesets.
+    /// Bundle state can be set on initialization if we want to use preloaded
+    /// bundle.
+    pub bundle_state: BundleState,
+    /// Addition layer that is going to be used to fetched values before
+    /// fetching values from database.
+    ///
+    /// Bundle is the main output of the state execution and this allows
+    /// setting previous bundle and using its values for execution.
+    pub use_preloaded_bundle: bool,
+    /// If EVM asks for block hash we will first check if they are found here.
+    /// and then ask the database.
+    ///
+    /// This map can be used to give different values for block hashes if in
+    /// case the fork block is different or some blocks are not saved inside
+    /// database.
+    pub block_hashes: RwLock<BTreeMap<u64, B256>>,
+}
+
+impl<DB: DatabaseRef> ConcurrentState<DB> {
+    /// Returns the size hint for the inner bundle state.
+    /// See [BundleState::size_hint] for more info.
+    pub fn bundle_size_hint(&self) -> usize {
+        self.info.bundle_state.size_hint()
+    }
+
+    /// Iterate over received balances and increment all account balances.
+    /// If account is not found inside cache state it will be loaded from database.
+    ///
+    /// Update will create transitions for all accounts that are updated.
+    ///
+    /// Like [CacheAccount::increment_balance], this assumes that incremented balances are not
+    /// zero, and will not overflow once incremented. If using this to implement withdrawals, zero
+    /// balances must be filtered out before calling this function.
+    pub fn increment_balances(
+        &mut self,
+        balances: impl IntoIterator<Item = (Address, u128)>,
+    ) -> Result<(), DB::Error> {
+        // make transition and update cache state
+        let mut transitions = Vec::new();
+        for (address, balance) in balances {
+            if balance == 0 {
+                continue;
+            }
+            let mut original_account = self.load_cache_account(address)?;
+            transitions.push((
+                address,
+                original_account.increment_balance(balance).expect("Balance is not zero"),
+            ))
+        }
+        // append transition
+        if let Some(s) = self.info.transition_state.as_mut() {
+            s.add_transitions(transitions)
+        }
+        Ok(())
+    }
+
+    /// Drain balances from given account and return those values.
+    ///
+    /// It is used for DAO hardfork state change to move values from given accounts.
+    pub fn drain_balances(
+        &mut self,
+        addresses: impl IntoIterator<Item = Address>,
+    ) -> Result<Vec<u128>, DB::Error> {
+        // make transition and update cache state
+        let mut transitions = Vec::new();
+        let mut balances = Vec::new();
+        for address in addresses {
+            let mut original_account = self.load_cache_account(address)?;
+            let (balance, transition) = original_account.drain_balance();
+            balances.push(balance);
+            transitions.push((address, transition))
+        }
+        // append transition
+        if let Some(s) = self.info.transition_state.as_mut() {
+            s.add_transitions(transitions)
+        }
+        Ok(balances)
+    }
+
+    /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
+    pub fn set_state_clear_flag(&self, has_state_clear: bool) {
+        self.info.cache.set_state_clear_flag(has_state_clear);
+    }
+
+    /// Insert not existing account into cache state.
+    pub fn insert_not_existing(&self, address: Address) {
+        self.info.cache.insert_not_existing(address)
+    }
+
+    /// Insert account into cache state.
+    pub fn insert_account(&self, address: Address, info: AccountInfo) {
+        self.info.cache.insert_account(address, info)
+    }
+
+    /// Insert account with storage into cache state.
+    pub fn insert_account_with_storage(
+        &mut self,
+        address: Address,
+        info: AccountInfo,
+        storage: PlainStorage,
+    ) {
+        self.info.cache.insert_account_with_storage(address, info, storage)
+    }
+
+    /// Apply evm transitions to transition state.
+    pub fn apply_transition(&mut self, transitions: Vec<(Address, TransitionAccount)>) {
+        // add transition to transition state.
+        if let Some(s) = self.info.transition_state.as_mut() {
+            s.add_transitions(transitions)
+        }
+    }
+
+    /// Take all transitions and merge them inside bundle state.
+    /// This action will create final post state and all reverts so that
+    /// we at any time revert state of bundle to the state before transition
+    /// is applied.
+    pub fn merge_transitions(&mut self, retention: BundleRetention) {
+        if let Some(transition_state) =
+            self.info.transition_state.as_mut().map(TransitionState::take)
+        {
+            self.info
+                .bundle_state
+                .apply_transitions_and_create_reverts(transition_state, retention);
+        }
+    }
+
+    /// Get a mutable reference to the [`CacheAccount`] for the given address.
+    /// If the account is not found in the cache, it will be loaded from the
+    /// database and inserted into the cache.
+    pub fn load_cache_account(
+        &self,
+        address: Address,
+    ) -> Result<RefMut<'_, Address, CacheAccount>, DB::Error> {
+        match self.info.cache.accounts.entry(address) {
+            dashmap::Entry::Vacant(entry) => {
+                if self.info.use_preloaded_bundle {
+                    // load account from bundle state
+                    if let Some(account) =
+                        self.info.bundle_state.account(&address).cloned().map(Into::into)
+                    {
+                        return Ok(entry.insert(account));
+                    }
+                }
+                // if not found in bundle, load it from database
+                let info = self.database.basic_ref(address)?;
+                let account = match info {
+                    None => CacheAccount::new_loaded_not_existing(),
+                    Some(acc) if acc.is_empty() => {
+                        CacheAccount::new_loaded_empty_eip161(PlainStorage::default())
+                    }
+                    Some(acc) => CacheAccount::new_loaded(acc, PlainStorage::default()),
+                };
+                Ok(entry.insert(account))
+            }
+            dashmap::Entry::Occupied(entry) => Ok(entry.into_ref()),
+        }
+    }
+
+    // TODO make cache aware of transitions dropping by having global transition counter.
+    /// Takes the [`BundleState`] changeset from the [`State`], replacing it
+    /// with an empty one.
+    ///
+    /// This will not apply any pending [`TransitionState`]. It is recommended
+    /// to call [`State::merge_transitions`] before taking the bundle.
+    ///
+    /// If the `State` has been built with the
+    /// [`StateBuilder::with_bundle_prestate`] option, the pre-state will be
+    /// taken along with any changes made by [`State::merge_transitions`].
+    pub fn take_bundle(&mut self) -> BundleState {
+        core::mem::take(&mut self.info.bundle_state)
+    }
+}
+
+impl<DB: DatabaseRef> DatabaseRef for ConcurrentState<DB> {
+    type Error = DB::Error;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.load_cache_account(address).map(|a| a.account_info())
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        let res = match self.info.cache.contracts.entry(code_hash) {
+            dashmap::Entry::Occupied(entry) => Ok(entry.get().clone()),
+            dashmap::Entry::Vacant(entry) => {
+                if self.info.use_preloaded_bundle {
+                    if let Some(code) = self.info.bundle_state.contracts.get(&code_hash) {
+                        entry.insert(code.clone());
+                        return Ok(code.clone());
+                    }
+                }
+                // if not found in bundle ask database
+                let code = self.database.code_by_hash_ref(code_hash)?;
+                entry.insert(code.clone());
+                Ok(code)
+            }
+        };
+        res
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        // Account is guaranteed to be loaded.
+        // Note that storage from bundle is already loaded with account.
+        if let Some(mut account) = self.info.cache.accounts.get_mut(&address) {
+            // account will always be some, but if it is not, U256::ZERO will be returned.
+            let is_storage_known = account.status.is_storage_known();
+            Ok(account
+                .account
+                .as_mut()
+                .map(|account| match account.storage.entry(index) {
+                    hash_map::Entry::Occupied(entry) => Ok(*entry.get()),
+                    hash_map::Entry::Vacant(entry) => {
+                        // if account was destroyed or account is newly built
+                        // we return zero and don't ask database.
+                        let value = if is_storage_known {
+                            U256::ZERO
+                        } else {
+                            self.database.storage_ref(address, index)?
+                        };
+                        entry.insert(value);
+                        Ok(value)
+                    }
+                })
+                .transpose()?
+                .unwrap_or_default())
+        } else {
+            unreachable!("For accessing any storage account is guaranteed to be loaded beforehand")
+        }
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        {
+            let hashes = self.info.block_hashes.read().unwrap();
+            if let Some(hash) = hashes.get(&number) {
+                return Ok(*hash);
+            }
+        }
+
+        let hash = self.database.block_hash_ref(number)?;
+
+        let mut hashes = self.info.block_hashes.write().unwrap();
+
+        hashes.insert(number, hash);
+
+        // prune all hashes that are older then BLOCK_HASH_HISTORY
+        let last_block = number.saturating_sub(revm::primitives::BLOCK_HASH_HISTORY);
+
+        // lock the hashes, split at the key, and retain the newer hashes
+        let mut hashes = self.info.block_hashes.write().unwrap();
+        let to_retain = hashes.split_off(&last_block);
+        *hashes = to_retain;
+
+        Ok(hash)
+    }
+}
+
+impl<DB: DatabaseRef> DatabaseCommit for ConcurrentState<DB> {
+    fn commit(&mut self, evm_state: revm::primitives::HashMap<Address, Account>) {
+        let transitions = self.info.cache.apply_evm_state(evm_state);
+        self.apply_transition(transitions);
+    }
+}
+
+// Some code above and documentation is adapted from the revm crate, and is
+// reproduced here under the terms of the MIT license.
+//
+// MIT License
+//
+// Copyright (c) 2021-2024 draganrakita
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -1,4 +1,5 @@
 use crate::db::ConcurrentCacheState;
+use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{Address, B256, U256};
 use dashmap::mapref::one::RefMut;
 use revm::{
@@ -9,10 +10,7 @@ use revm::{
     primitives::{Account, AccountInfo, Bytecode},
     Database, DatabaseCommit, DatabaseRef, TransitionAccount, TransitionState,
 };
-use std::{
-    collections::{hash_map, BTreeMap},
-    sync::RwLock,
-};
+use std::{collections::hash_map, sync::RwLock};
 
 /// State of blockchain.
 ///

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -883,9 +883,9 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
 impl<Ext, Db: Database> EvmNeedsBlock<'_, Ext, State<Db>> {
     /// Finish execution and return the outputs.
     ///
-    /// ## Panics
-    ///
-    /// If the State has not been built with StateBuilder::with_bundle_update.
+    /// If the State has not been built with
+    /// [revm::StateBuilder::with_bundle_update] then the returned
+    /// [`BundleState`] will be meaningless.
     ///
     /// See [`State::merge_transitions`] and [`State::take_bundle`].
     pub fn finish(self) -> BundleState {

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1,8 +1,8 @@
 use crate::{
-    db::ConcurrentState, driver::DriveBlockResult, Block, BlockDriver, BundleDriver, Cfg,
-    ChainDriver, DriveBundleResult, DriveChainResult, ErroredState, EvmErrored, EvmExtUnchecked,
-    EvmNeedsBlock, EvmNeedsCfg, EvmNeedsTx, EvmReady, EvmTransacted, HasBlock, HasCfg, HasTx,
-    NeedsCfg, NeedsTx, TransactedState, Tx,
+    driver::DriveBlockResult, Block, BlockDriver, BundleDriver, Cfg, ChainDriver,
+    DriveBundleResult, DriveChainResult, ErroredState, EvmErrored, EvmExtUnchecked, EvmNeedsBlock,
+    EvmNeedsCfg, EvmNeedsTx, EvmReady, EvmTransacted, HasBlock, HasCfg, HasTx, NeedsCfg, NeedsTx,
+    TransactedState, Tx,
 };
 use alloc::{boxed::Box, fmt};
 use alloy_primitives::{Address, Bytes, U256};
@@ -20,8 +20,8 @@ use revm::{
 ///
 /// See the [crate-level documentation](crate) for more information.
 pub struct Trevm<'a, Ext, Db: Database + DatabaseCommit, TrevmState> {
-    inner: Box<Evm<'a, Ext, Db>>,
-    state: TrevmState,
+    pub(crate) inner: Box<Evm<'a, Ext, Db>>,
+    pub(crate) state: TrevmState,
 }
 
 impl<Ext, Db: Database + DatabaseCommit, TrevmState> fmt::Debug for Trevm<'_, Ext, Db, TrevmState> {
@@ -440,17 +440,9 @@ impl<Ext, Db: Database<Error = Infallible> + DatabaseCommit, TrevmState>
     }
 }
 
-// --- ALL STATES, WITH State<Db> or ConcurrentState<Db>
+// --- ALL STATES, WITH State<Db>
 
 impl<Ext, Db: Database + DatabaseCommit, TrevmState> Trevm<'_, Ext, State<Db>, TrevmState> {
-    /// Set the [EIP-161] state clear flag, activated in the Spurious Dragon
-    /// hardfork.
-    pub fn set_state_clear_flag(&mut self, flag: bool) {
-        self.inner.db_mut().set_state_clear_flag(flag)
-    }
-}
-
-impl<Ext, Db: DatabaseRef, TrevmState> Trevm<'_, Ext, ConcurrentState<Db>, TrevmState> {
     /// Set the [EIP-161] state clear flag, activated in the Spurious Dragon
     /// hardfork.
     pub fn set_state_clear_flag(&mut self, flag: bool) {
@@ -886,26 +878,9 @@ impl<'a, Ext, Db: Database + DatabaseCommit, TrevmState: HasBlock> Trevm<'a, Ext
     }
 }
 
-// --- Needs Block with State<Db> or ConcurrentState<Db>
+// --- Needs Block with State<Db>
 
 impl<Ext, Db: Database> EvmNeedsBlock<'_, Ext, State<Db>> {
-    /// Finish execution and return the outputs.
-    ///
-    /// ## Panics
-    ///
-    /// If the State has not been built with StateBuilder::with_bundle_update.
-    ///
-    /// See [`State::merge_transitions`] and [`State::take_bundle`].
-    pub fn finish(self) -> BundleState {
-        let Self { inner: mut evm, .. } = self;
-        evm.db_mut().merge_transitions(BundleRetention::Reverts);
-        let bundle = evm.db_mut().take_bundle();
-
-        bundle
-    }
-}
-
-impl<'a, Ext, Db: DatabaseRef> EvmNeedsBlock<'a, Ext, ConcurrentState<Db>> {
     /// Finish execution and return the outputs.
     ///
     /// ## Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ mod connect;
 pub use connect::{DbConnect, EvmFactory};
 
 /// Contains database implementations for concurrent EVM operation.
+#[cfg(feature = "concurrent-db")]
 pub mod db;
 
 mod driver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,9 @@ extern crate alloc;
 mod connect;
 pub use connect::{DbConnect, EvmFactory};
 
+/// Contains database implementations for concurrent EVM operation.
+pub mod db;
+
 mod driver;
 pub use driver::{
     BlockDriver, BundleDriver, ChainDriver, DriveBlockResult, DriveBundleResult, DriveChainResult,


### PR DESCRIPTION
Adds a concurrently accessible version of the `State<Db>` from Revm. This manages a cache that can be updated by multiple threads via dashmap and an rwlock. The transitions can NOT be shared and require `&mut self`. The idea is that we should `Arc` it and then drop the users and use `Arc::get_mut` to manage transitions