### PR TITLE
fix: gas estimation for simple transfers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.19.3"
+version = "0.19.5"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]
@@ -32,7 +32,7 @@ alloy-sol-types = { version = "0.8.11", default-features = false, features = ["s
 
 alloy = { version = "=0.9.2", default-features = false, features = ["consensus", "rpc-types-mev", "eips", "k256", "std"] }
 
-revm = { version = "19.2.0", default-features = false, features = ["std"] }
+revm = { version = "19.5.0", default-features = false, features = ["std"] }
 
 zenith-types = { version = "0.14" }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 mod builder;
 
+use alloy::rpc::types::BlockOverrides;
 pub use builder::ConcurrentStateBuilder;
 
 mod cache_state;
@@ -8,7 +9,7 @@ pub use cache_state::ConcurrentCacheState;
 mod sync_state;
 pub use sync_state::{ConcurrentState, ConcurrentStateInfo};
 
-use crate::{EvmNeedsBlock, Trevm};
+use crate::{Block, EvmNeedsBlock, EvmNeedsTx, Trevm};
 use revm::{
     db::{states::bundle_state::BundleRetention, BundleState},
     DatabaseRef,
@@ -39,5 +40,37 @@ impl<Ext, Db: DatabaseRef + Sync> EvmNeedsBlock<'_, Ext, ConcurrentState<Db>> {
         let bundle = evm.db_mut().take_bundle();
 
         bundle
+    }
+}
+
+impl<Ext, Db: DatabaseRef + Sync> EvmNeedsTx<'_, Ext, ConcurrentState<Db>> {
+    /// Apply block overrides to the current block.
+    ///
+    /// Note that this is NOT reversible. The overrides are applied directly to
+    /// the underlying state and these changes cannot be removed. If it is
+    /// important that you have access to the pre-change state, you should wrap
+    /// the existing DB in a new [`State`] and apply the overrides to that.
+    pub fn apply_block_overrides(mut self, overrides: &BlockOverrides) -> Self {
+        overrides.fill_block(&mut self.inner);
+
+        if let Some(hashes) = &overrides.block_hash {
+            self.inner.db_mut().info.block_hashes.write().unwrap().extend(hashes)
+        }
+
+        self
+    }
+
+    /// Apply block overrides to the current block, if they are provided.
+    ///
+    /// Note that this is NOT reversible. The overrides are applied directly to
+    /// the underlying state and these changes cannot be removed. If it is
+    /// important that you have access to the pre-change state, you should wrap
+    /// the existing DB in a new [`State`] and apply the overrides to that.
+    pub fn maybe_apply_block_overrides(self, overrides: Option<&BlockOverrides>) -> Self {
+        if let Some(overrides) = overrides {
+            self.apply_block_overrides(overrides)
+        } else {
+            self
+        }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -49,7 +49,8 @@ impl<Ext, Db: DatabaseRef + Sync> EvmNeedsTx<'_, Ext, ConcurrentState<Db>> {
     /// Note that this is NOT reversible. The overrides are applied directly to
     /// the underlying state and these changes cannot be removed. If it is
     /// important that you have access to the pre-change state, you should wrap
-    /// the existing DB in a new [`State`] and apply the overrides to that.
+    /// the existing DB in a new [`ConcurrentState`] and apply the overrides to
+    /// that.
     pub fn apply_block_overrides(mut self, overrides: &BlockOverrides) -> Self {
         overrides.fill_block(&mut self.inner);
 
@@ -65,7 +66,8 @@ impl<Ext, Db: DatabaseRef + Sync> EvmNeedsTx<'_, Ext, ConcurrentState<Db>> {
     /// Note that this is NOT reversible. The overrides are applied directly to
     /// the underlying state and these changes cannot be removed. If it is
     /// important that you have access to the pre-change state, you should wrap
-    /// the existing DB in a new [`State`] and apply the overrides to that.
+    /// the existing DB in a new [`ConcurrentState`] and apply the overrides to
+    /// that.
     pub fn maybe_apply_block_overrides(self, overrides: Option<&BlockOverrides>) -> Self {
         if let Some(overrides) = overrides {
             self.apply_block_overrides(overrides)

--- a/src/est.rs
+++ b/src/est.rs
@@ -1,4 +1,3 @@
-use crate::MIN_TRANSACTION_GAS;
 use revm::primitives::{Bytes, ExecutionResult, HaltReason, Output};
 use std::ops::Range;
 
@@ -132,11 +131,11 @@ impl From<&ExecutionResult> for EstimationResult {
 
 impl EstimationResult {
     /// Create a successful estimation result with a gas estimation of 21000.
-    pub const fn basic_transfer_success() -> Self {
+    pub const fn basic_transfer_success(estimation: u64) -> Self {
         Self::Success {
-            estimation: MIN_TRANSACTION_GAS,
+            estimation,
             refund: 0,
-            gas_used: MIN_TRANSACTION_GAS,
+            gas_used: estimation,
             output: Output::Call(Bytes::new()),
         }
     }

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1304,7 +1304,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmReady<'a, Ext, Db> {
 
         // delegate calculation to revm. This ensures that things like bogus
         // 2930 access lists don't mess up our estimates
-        Ok(Some(self.caluculate_initial_gas()))
+        Ok(Some(self.calculate_initial_gas()))
     }
 
     /// Convenience function to simplify nesting of [`Self::estimate_gas`].

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1399,7 +1399,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmReady<'a, Ext, Db> {
         search_range.maybe_lower_max(allowance);
 
         // Raise the floor to the amount of gas required to initialize the EVM.
-        search_range.maybe_raise_min(self.caluculate_initial_gas());
+        search_range.maybe_raise_min(self.calculate_initial_gas());
 
         // Run an estimate with the max gas limit.
         // NB: we declare these mut as we re-use the binding throughout the

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1272,7 +1272,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmReady<'a, Ext, Db> {
     ///
     /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
-    fn caluculate_initial_gas(&self) -> u64 {
+    fn calculate_initial_gas(&self) -> u64 {
         calculate_initial_tx_gas(
             self.spec_id(),
             &[],


### PR DESCRIPTION
the basic transfer estimation failed when eip2930 or eip7702 attributes were present, by underestimating the gas required.

This is an edge case, as users don't generally attach spurious info that costs money, but regularly encountered during testing things like `eth_estimateGas`