### PR TITLE
Always set randao in alloy block filler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.19.5"
+version = "0.19.6"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Trevm is useful for:
 - searchers
 - any other transaction simulation usecase
 
+## Note on Trevm Versioning
+
+Trevm generally uses [semantic versioning](https://semver.org/). However, we
+also strive to indicate the MAJOR version of revm in the MINOR version of
+trevm. For example, trevm `0.19.x` SHOULD BE compatible with revm `19.x.x`. In
+general, we will try to maintain compatibility with the latest revm version,
+and will not backport trevm fixes to older trevm or revm versions. It is
+generally not advised to use old revm versions, as the EVM is a living spec.
+
 ## Limitations
 
 Trevm is a work in progress and is not feature complete. In particular, trevm

--- a/src/fill/alloy.rs
+++ b/src/fill/alloy.rs
@@ -236,7 +236,7 @@ impl Block for alloy::consensus::Header {
         *basefee = self.base_fee_per_gas.map_or_else(Default::default, U256::from);
 
         *difficulty = self.difficulty;
-        *prevrandao = if self.difficulty.is_zero() { Some(self.mix_hash) } else { None };
+        *prevrandao = Some(self.mix_hash);
 
         if let Some(excess_blob_gas) = self.excess_blob_gas {
             block_env


### PR DESCRIPTION
Previous logic appears to be erroneous, and never sets prevrandao

always setting is safe, as it cannot be accessed outside of the post-merge specs