### PR TITLE
Allowance interface tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.19.6"
+version = "0.19.7"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tokio = { version = "1.39", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = [
+    "call",
     "concurrent-db",
     "estimate_gas",
     "revm/std",
@@ -63,6 +64,8 @@ default = [
     "revm/portable",
     "revm/secp256k1",
 ]
+
+call = ["optional_eip3607", "optional_no_base_fee"]
 
 concurrent-db = ["dep:dashmap"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ revm = { version = "19.5.0", default-features = false, features = ["std"] }
 zenith-types = { version = "0.14" }
 
 dashmap = { version = "6.1.0", optional = true }
+tracing = "0.1.41"
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ Trevm is useful for:
 
 ## Note on Trevm Versioning
 
-Trevm generally uses [semantic versioning](https://semver.org/). However, we
-also strive to indicate the MAJOR version of revm in the MINOR version of
+Trevm generally uses [semantic versioning](https://semver.org/). While pre-1.0,
+we also strive to indicate the MAJOR version of revm in the MINOR version of
 trevm. For example, trevm `0.19.x` SHOULD BE compatible with revm `19.x.x`. In
 general, we will try to maintain compatibility with the latest revm version,
 and will not backport trevm fixes to older trevm or revm versions. It is
 generally not advised to use old revm versions, as the EVM is a living spec.
+
+In order to maintain this relationship (that trevm MINOR == revm MAJOR) we will
+sometimes make breaking changes in patch versions. This is technically semver
+compliant pre-1.0, but will cause build breakage downstream for users of those
+features. We will take care to document breaking changes in patch releases
+via github release notes.
 
 ## Limitations
 

--- a/src/est.rs
+++ b/src/est.rs
@@ -5,6 +5,12 @@ use std::ops::Range;
 /// binary searching.
 pub(crate) struct SearchRange(Range<u64>);
 
+impl core::fmt::Display for SearchRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}..{}", self.0.start, self.0.end)
+    }
+}
+
 impl From<Range<u64>> for SearchRange {
     fn from(value: Range<u64>) -> Self {
         Self(value)
@@ -25,7 +31,7 @@ impl SearchRange {
 
     /// Calculate the midpoint of the search range.
     pub(crate) const fn midpoint(&self) -> u64 {
-        (self.0.end - self.0.start) / 2
+        (self.max() - self.min()) / 2 + self.min()
     }
 
     /// Get the start of the search range.
@@ -38,6 +44,7 @@ impl SearchRange {
         self.0.start = min;
     }
 
+    /// Raise the minimum of the search range, if the candidate is higher.
     pub(crate) const fn maybe_raise_min(&mut self, candidate: u64) {
         if candidate > self.min() {
             self.set_min(candidate);

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1598,7 +1598,7 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmReady<'a, Ext, Db> {
         needle = std::cmp::min(gas_used * 3, search_range.midpoint());
 
         // Binary search loop.
-        // This is a heuristic adopted from reth
+        // The second conditional is a heuristic adopted from geth and reth.
         // An estimation error is allowed once the current gas limit range
         // used in the binary search is small enough (less than 1.5% of the
         // highest gas limit)
@@ -1812,7 +1812,9 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmTransacted<'a, Ext, Db> {
     /// [`EstimationResult`]: crate::EstimationResult
     #[cfg(feature = "estimate_gas")]
     pub fn estimation(&self) -> crate::EstimationResult {
-        self.result().into()
+        use crate::EstimationResult;
+
+        EstimationResult::from_limit_and_execution_result(self.gas_limit(), self.result())
     }
 
     /// Take the [`EstimationResult`] and return it and the EVM. This discards

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1477,6 +1477,8 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmReady<'a, Ext, Db> {
     ///     - Loop.
     ///
     /// [here]: https://github.com/paradigmxyz/reth/blob/ad503a08fa242b28ad3c1fea9caa83df2dfcf72d/crates/rpc/rpc-eth-api/src/helpers/estimate.rs#L35-L42
+    /// [`EstimationREsult`]: crate::EstimationResult
+    /// [`MIN_TRANSACTION_GAS`]: crate::MIN_TRANSACTION_GAS
     #[cfg(feature = "estimate_gas")]
     pub fn estimate_gas(
         mut self,

--- a/src/fill/alloy.rs
+++ b/src/fill/alloy.rs
@@ -303,7 +303,10 @@ impl Tx for alloy::rpc::types::TransactionRequest {
         } = tx_env;
 
         *caller = self.from.unwrap_or_default();
-        *gas_limit = self.gas.unwrap_or_default();
+
+        // NB: this is set to max if not provided, as users will typically
+        // intend that to mean "as much as possible"
+        *gas_limit = self.gas.unwrap_or(u64::MAX);
         *gas_price = U256::from(self.gas_price.unwrap_or_default());
         *transact_to = self.to.unwrap_or_default();
         *value = self.value.unwrap_or_default();

--- a/src/fill/fillers.rs
+++ b/src/fill/fillers.rs
@@ -1,8 +1,5 @@
-use crate::{
-    fill::traits::{Cfg, Tx},
-    Block,
-};
-use revm::primitives::{BlockEnv, CfgEnv, TxEnv};
+use crate::fill::traits::{Cfg, Tx};
+use revm::primitives::{CfgEnv, TxEnv};
 
 /// A [`Cfg`] that disables gas-related checks and payment of the
 /// beneficiary reward, while leaving other cfg options unchanged.
@@ -102,8 +99,8 @@ impl Cfg for CallFiller {
 }
 
 #[cfg(feature = "call")]
-impl Block for CallFiller {
-    fn fill_block_env(&self, block_env: &mut BlockEnv) {
+impl crate::Block for CallFiller {
+    fn fill_block_env(&self, block_env: &mut revm::primitives::BlockEnv) {
         block_env.gas_limit = alloy::primitives::U256::from(self.gas_limit);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,9 @@ pub use driver::{
 mod evm;
 pub use evm::Trevm;
 
+#[cfg(feature = "estimate_gas")]
 mod est;
+#[cfg(feature = "estimate_gas")]
 pub use est::EstimationResult;
 
 mod ext;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,12 @@ macro_rules! trevm_bail {
 #[cfg(feature = "estimate_gas")]
 macro_rules! estimate_and_adjust {
     ($est:ident, $trevm:ident, $gas_limit:ident, $range:ident) => {
+        ::tracing::trace!(
+            gas_limit = $gas_limit,
+            range = %$range,
+            "running gas estimate call"
+        );
+
         ($est, $trevm) = $trevm.run_estimate(&$gas_limit.into())?;
         if let Err(e) = $est.adjust_binary_search_range($gas_limit, &mut $range) {
             return Ok((e, $trevm));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,6 +32,7 @@ macro_rules! trevm_bail {
 macro_rules! estimate_and_adjust {
     ($est:ident, $trevm:ident, $gas_limit:ident, $range:ident) => {
         ::tracing::trace!(
+            estimate = %$est,
             gas_limit = $gas_limit,
             range = %$range,
             "running gas estimate call"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,6 +28,7 @@ macro_rules! trevm_bail {
 }
 
 /// Macro for gas estimation binary search loop.
+#[cfg(feature = "estimate_gas")]
 macro_rules! estimate_and_adjust {
     ($est:ident, $trevm:ident, $gas_limit:ident, $range:ident) => {
         ($est, $trevm) = $trevm.run_estimate(&$gas_limit.into())?;


### PR DESCRIPTION
Changes the allowance interface to make it usable when no TX is loaded, for any account.

This is a non-semver breaking change, and i have expanded on repo policy there in the readme.

includes drive-by cleanup of lints and compilation errors for no-default-features and all features