### PR TITLE
chore: bump alloy and zenith deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.19.7"
+version = "0.19.8"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]
@@ -27,21 +27,17 @@ option-if-let-else = "warn"
 redundant-clone = "warn"
 
 [dependencies]
-alloy-rlp = { version = "0.3.10", default-features = false, features = ["std"]}
-alloy-sol-types = { version = "0.8.11", default-features = false, features = ["std"]}
-
-alloy = { version = "=0.9.2", default-features = false, features = ["consensus", "rpc-types-mev", "eips", "k256", "std"] }
+alloy = { version = "=0.11.1", default-features = false, features = ["consensus", "rpc-types-mev", "eips", "k256", "std", "rlp", "sol-types"] }
 
 revm = { version = "19.5.0", default-features = false, features = ["std"] }
 
-zenith-types = { version = "0.14" }
+zenith-types = { version = "0.15" }
 
 dashmap = { version = "6.1.0", optional = true }
 tracing = { version = "0.1.41", optional = true}
 
 [dev-dependencies]
-alloy-rlp = { version = "0.3", default-features = false }
-revm = { version = "19.0.0", features = [
+revm = { version = "19.5.0", features = [
     "test-utils",
     "serde-json",
     "std",

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1763,13 +1763,13 @@ impl<'a, Ext, Db: Database + DatabaseCommit> EvmTransacted<'a, Ext, Db> {
     /// a [`SolCall`]. If `validate` is true, the output will be type- and
     /// range-checked.
     ///
-    /// [`SolCall`]: alloy_sol_types::SolCall
-    pub fn output_sol<T: alloy_sol_types::SolCall>(
+    /// [`SolCall`]: alloy::sol_types::SolCall
+    pub fn output_sol<T: alloy::sol_types::SolCall>(
         &self,
         validate: bool,
-    ) -> Option<alloy_sol_types::Result<T::Return>>
+    ) -> Option<alloy::sol_types::Result<T::Return>>
     where
-        T::Return: alloy_sol_types::SolType,
+        T::Return: alloy::sol_types::SolType,
     {
         self.output().map(|output| T::abi_decode_returns(output, validate))
     }

--- a/src/fill/alloy.rs
+++ b/src/fill/alloy.rs
@@ -380,10 +380,10 @@ impl Block for alloy::rpc::types::BlockOverrides {
 #[cfg(test)]
 mod tests {
     use crate::{NoopBlock, NoopCfg, TrevmBuilder};
-    use alloy::consensus::{Header, TxEnvelope, EMPTY_ROOT_HASH};
-
-    use alloy_rlp::Decodable;
-
+    use alloy::{
+        consensus::{Header, TxEnvelope, EMPTY_ROOT_HASH},
+        rlp::Decodable,
+    };
     use revm::{Evm, InMemoryDB};
 
     #[test]

--- a/src/fill/zenith.rs
+++ b/src/fill/zenith.rs
@@ -1,6 +1,8 @@
 use crate::{Block, Tx};
-use alloy::primitives::{Address, U256};
-use alloy_sol_types::SolCall;
+use alloy::{
+    primitives::{Address, U256},
+    sol_types::SolCall,
+};
 use revm::primitives::{TransactTo, TxEnv};
 use zenith_types::{Passage::EnterToken, Transactor, ZenithCallBundle};
 

--- a/src/journal/coder.rs
+++ b/src/journal/coder.rs
@@ -1,6 +1,8 @@
 use crate::journal::{AcctDiff, BundleStateIndex, InfoOutcome};
-use alloy::primitives::{Address, Bytes, B256, U256};
-use alloy_rlp::{Buf, BufMut};
+use alloy::{
+    primitives::{Address, Bytes, B256, U256},
+    rlp::{Buf, BufMut},
+};
 use revm::{
     db::{states::StorageSlot, BundleState},
     primitives::{
@@ -14,7 +16,6 @@ use std::{
     sync::Arc,
     vec::Vec,
 };
-
 use zenith_types::Zenith;
 
 type Result<T, E = JournalDecodeError> = core::result::Result<T, E>;

--- a/src/system/eip6110.rs
+++ b/src/system/eip6110.rs
@@ -1,12 +1,14 @@
-use alloy::consensus::ReceiptEnvelope;
-use alloy::primitives::{Bytes, Log};
-use alloy_rlp::BufMut;
-use alloy_sol_types::{sol, SolEvent};
+use alloy::{
+    consensus::ReceiptEnvelope,
+    primitives::{Bytes, Log},
+    rlp::BufMut,
+    sol_types::SolEvent,
+};
 
 /// The address for the Ethereum 2.0 deposit contract on the mainnet.
 pub use alloy::eips::eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS;
 
-sol! {
+alloy::sol! {
     #[allow(missing_docs)]
     event DepositEvent(
         bytes pubkey,


### PR DESCRIPTION
Bumps deps to match reth @ 1.2.0, removes separate deps on alloy-rlp and alloy-sol-types

this is a breaking change, as per policy in readme