### PR TITLE
fix: restore commit bounds to drivers

### DIFF
--- a/src/driver/block.rs
+++ b/src/driver/block.rs
@@ -1,5 +1,5 @@
 use crate::{Block, EvmBlockDriverErrored, EvmNeedsBlock, EvmNeedsTx};
-use revm::{primitives::EVMError, Database};
+use revm::{primitives::EVMError, Database, DatabaseCommit};
 
 /// The result of running transactions for a block driver.
 pub type RunTxResult<'a, Ext, Db, T> =
@@ -17,19 +17,19 @@ pub trait BlockDriver<Ext> {
     type Block: Block;
 
     /// An error type for this driver.
-    type Error<Db: Database>: core::error::Error + From<EVMError<Db::Error>>;
+    type Error<Db: Database + DatabaseCommit>: core::error::Error + From<EVMError<Db::Error>>;
 
     /// Get a reference to the block filler for this driver.
     fn block(&self) -> &Self::Block;
 
     /// Run the transactions for the block.
-    fn run_txns<'a, Db: Database>(
+    fn run_txns<'a, Db: Database + DatabaseCommit>(
         &mut self,
         trevm: EvmNeedsTx<'a, Ext, Db>,
     ) -> RunTxResult<'a, Ext, Db, Self>;
 
     /// Run post
-    fn post_block<Db: Database>(
+    fn post_block<Db: Database + DatabaseCommit>(
         &mut self,
         trevm: &EvmNeedsBlock<'_, Ext, Db>,
     ) -> Result<(), Self::Error<Db>>;

--- a/src/driver/bundle.rs
+++ b/src/driver/bundle.rs
@@ -9,7 +9,7 @@ pub type DriveBundleResult<'a, Ext, Db, T> =
 /// entire lifecycle of a bundle, simulating the entire list of transactions.
 pub trait BundleDriver<Ext> {
     /// An error type for this driver.
-    type Error<Db: Database>: core::error::Error + From<EVMError<Db::Error>>;
+    type Error<Db: Database + DatabaseCommit>: core::error::Error + From<EVMError<Db::Error>>;
 
     /// Run the transactions contained in the bundle.
     fn run_bundle<'a, Db: Database + DatabaseCommit>(

--- a/src/driver/chain.rs
+++ b/src/driver/chain.rs
@@ -14,7 +14,7 @@ pub trait ChainDriver<Ext> {
     type BlockDriver: BlockDriver<Ext>;
 
     /// An error type for this driver.
-    type Error<Db: Database>: core::error::Error
+    type Error<Db: Database + DatabaseCommit>: core::error::Error
         + From<EVMError<Db::Error>>
         + From<<Self::BlockDriver as BlockDriver<Ext>>::Error<Db>>;
 


### PR DESCRIPTION
Drivers SHOULD be able to modify their DB state. Without this bound they can't effectively increment balances (e.g.)