### PR TITLE
refactor: trevm_try

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@
 //!
 //! [`EVMError<Db>`]: revm::primitives::EVMError<Db>
 //! [typestate pattern]: https://cliffle.com/blog/rust-typestate/
-//! [crate readme]: https://github.com/init4tt/trevm
+//! [crate readme]: https://github.com/init4tech/trevm
 //! [EIP-2537]: https://eips.ethereum.org/EIPS/eip-2537
 //! [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
 //! [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,18 @@
 /// Unwraps a Result, returning the value if successful, or returning an errored `Trevm` if not.
 #[macro_export]
+#[deprecated = "Please use `trevm_tri!` instead"]
 macro_rules! unwrap_or_trevm_err {
+    ($e:expr, $trevm:expr) => {
+        match $e {
+            Ok(val) => val,
+            Err(e) => return Err($trevm.errored(e.into())),
+        }
+    };
+}
+
+/// Unwraps a Result, returning the value if successful, or returning an errored `Trevm` if not.
+#[macro_export]
+macro_rules! trevm_try {
     ($e:expr, $trevm:expr) => {
         match $e {
             Ok(val) => val,


### PR DESCRIPTION
rename the `unwrap_or_trevm_error` macro to conform to more common standards

drive-by: includes the link fix from #90 