### PR TITLE
fix: db in driver traits again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.20.5"
+version = "0.20.6"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]

--- a/src/db/sync/cache.rs
+++ b/src/db/sync/cache.rs
@@ -59,7 +59,7 @@ impl ConcurrentCacheState {
     }
 
     /// Set state clear flag. EIP-161.
-    pub fn set_state_clear_flag(&mut self, has_state_clear: bool) {
+    pub const fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         self.has_state_clear = has_state_clear;
     }
 

--- a/src/db/sync/state.rs
+++ b/src/db/sync/state.rs
@@ -60,7 +60,7 @@ impl<Db> ConcurrentState<Db> {
     }
 
     /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
-    pub fn set_state_clear_flag(&mut self, has_state_clear: bool) {
+    pub const fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         self.info.cache.set_state_clear_flag(has_state_clear);
     }
 

--- a/src/driver/alloy.rs
+++ b/src/driver/alloy.rs
@@ -256,17 +256,17 @@ impl BundleProcessor<EthCallBundle, EthCallBundleResponse> {
     }
 }
 
-impl<Insp> BundleDriver<Insp> for BundleProcessor<EthCallBundle, EthCallBundleResponse> {
-    type Error<Db: Database + DatabaseCommit> = BundleError<Db>;
+impl<Db, Insp> BundleDriver<Db, Insp> for BundleProcessor<EthCallBundle, EthCallBundleResponse>
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
+    type Error = BundleError<Db>;
 
-    fn run_bundle<Db>(
+    fn run_bundle(
         &mut self,
         trevm: crate::EvmNeedsTx<Db, Insp>,
-    ) -> DriveBundleResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    ) -> DriveBundleResult<Db, Insp, Self> {
         // Check if the block we're in is valid for this bundle. Both must match
         trevm_ensure!(
             trevm.inner().block.number == self.bundle.block_number,
@@ -388,29 +388,22 @@ impl<Insp> BundleDriver<Insp> for BundleProcessor<EthCallBundle, EthCallBundleRe
         }
     }
 
-    fn post_bundle<Db>(
-        &mut self,
-        _trevm: &crate::EvmNeedsTx<Db, Insp>,
-    ) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    fn post_bundle(&mut self, _trevm: &crate::EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl<Insp> BundleDriver<Insp> for BundleProcessor<EthSendBundle, EthBundleHash> {
-    type Error<Db: Database + DatabaseCommit> = BundleError<Db>;
+impl<Db, Insp> BundleDriver<Db, Insp> for BundleProcessor<EthSendBundle, EthBundleHash>
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
+    type Error = BundleError<Db>;
 
-    fn run_bundle<Db>(
+    fn run_bundle(
         &mut self,
         trevm: crate::EvmNeedsTx<Db, Insp>,
-    ) -> DriveBundleResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    ) -> DriveBundleResult<Db, Insp, Self> {
         {
             // Check if the block we're in is valid for this bundle. Both must match
             trevm_ensure!(
@@ -483,14 +476,7 @@ impl<Insp> BundleDriver<Insp> for BundleProcessor<EthSendBundle, EthBundleHash> 
         }
     }
 
-    fn post_bundle<Db>(
-        &mut self,
-        _trevm: &crate::EvmNeedsTx<Db, Insp>,
-    ) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    fn post_bundle(&mut self, _trevm: &crate::EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -551,17 +537,17 @@ impl From<EthCallBundle> for BundleBlockFiller {
     }
 }
 
-impl<Insp> BundleDriver<Insp> for EthCallBundle {
-    type Error<Db: Database + DatabaseCommit> = BundleError<Db>;
+impl<Db, Insp> BundleDriver<Db, Insp> for EthCallBundle
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
+    type Error = BundleError<Db>;
 
-    fn run_bundle<Db>(
+    fn run_bundle(
         &mut self,
         trevm: crate::EvmNeedsTx<Db, Insp>,
-    ) -> DriveBundleResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    ) -> DriveBundleResult<Db, Insp, Self> {
         // Check if the block we're in is valid for this bundle. Both must match
         trevm_ensure!(
             trevm.inner().block.number == self.block_number,
@@ -634,14 +620,7 @@ impl<Insp> BundleDriver<Insp> for EthCallBundle {
         }
     }
 
-    fn post_bundle<Db>(
-        &mut self,
-        _trevm: &crate::EvmNeedsTx<Db, Insp>,
-    ) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    fn post_bundle(&mut self, _trevm: &crate::EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -649,17 +628,17 @@ impl<Insp> BundleDriver<Insp> for EthCallBundle {
 /// An implementation of [BundleDriver] for [EthSendBundle].
 /// This allows us to drive a bundle of transactions and accumulate the resulting state in the EVM.
 /// Allows to simply take an [EthSendBundle] and get the resulting EVM state.
-impl<Insp> BundleDriver<Insp> for EthSendBundle {
-    type Error<Db: Database + DatabaseCommit> = BundleError<Db>;
+impl<Db, Insp> BundleDriver<Db, Insp> for EthSendBundle
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
+    type Error = BundleError<Db>;
 
-    fn run_bundle<Db>(
+    fn run_bundle(
         &mut self,
         trevm: crate::EvmNeedsTx<Db, Insp>,
-    ) -> DriveBundleResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    ) -> DriveBundleResult<Db, Insp, Self> {
         // Check if the block we're in is valid for this bundle. Both must match
         trevm_ensure!(
             trevm.inner().block.number == self.block_number,
@@ -747,14 +726,7 @@ impl<Insp> BundleDriver<Insp> for EthSendBundle {
         Ok(t)
     }
 
-    fn post_bundle<Db>(
-        &mut self,
-        _trevm: &crate::EvmNeedsTx<Db, Insp>,
-    ) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>,
-    {
+    fn post_bundle(&mut self, _trevm: &crate::EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/src/driver/block.rs
+++ b/src/driver/block.rs
@@ -12,25 +12,22 @@ pub type DriveBlockResult<Db, Insp, T> =
 /// Driver for a single trevm block. This trait allows a type to specify the
 /// entire lifecycle of a trevm block, from opening the block to driving the
 /// trevm to completion.
-pub trait BlockDriver<Insp> {
+pub trait BlockDriver<Db, Insp>
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
     /// The [`Block`] filler for this driver.
     type Block: Block;
 
     /// An error type for this driver.
-    type Error<Db: Database + DatabaseCommit>: core::error::Error + From<EVMError<Db::Error>>;
+    type Error: core::error::Error + From<EVMError<Db::Error>>;
 
     /// Get a reference to the block filler for this driver.
     fn block(&self) -> &Self::Block;
 
     /// Run the transactions for the block.
-    fn run_txns<Db>(&mut self, trevm: EvmNeedsTx<Db, Insp>) -> RunTxResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>;
-
+    fn run_txns(&mut self, trevm: EvmNeedsTx<Db, Insp>) -> RunTxResult<Db, Insp, Self>;
     /// Run post
-    fn post_block<Db>(&mut self, trevm: &EvmNeedsBlock<Db, Insp>) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>;
+    fn post_block(&mut self, trevm: &EvmNeedsBlock<Db, Insp>) -> Result<(), Self::Error>;
 }

--- a/src/driver/bundle.rs
+++ b/src/driver/bundle.rs
@@ -7,19 +7,17 @@ pub type DriveBundleResult<Db, Insp, T> =
 
 /// Driver for a bundle of transactions. This trait allows a type to specify the
 /// entire lifecycle of a bundle, simulating the entire list of transactions.
-pub trait BundleDriver<Insp> {
+pub trait BundleDriver<Db, Insp>
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
     /// An error type for this driver.
-    type Error<Db: Database + DatabaseCommit>: core::error::Error + From<EVMError<Db::Error>>;
+    type Error: core::error::Error + From<EVMError<Db::Error>>;
 
     /// Run the transactions contained in the bundle.
-    fn run_bundle<Db>(&mut self, trevm: EvmNeedsTx<Db, Insp>) -> DriveBundleResult<Db, Insp, Self>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>;
+    fn run_bundle(&mut self, trevm: EvmNeedsTx<Db, Insp>) -> DriveBundleResult<Db, Insp, Self>;
 
     /// Run post
-    fn post_bundle<Db>(&mut self, trevm: &EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>;
+    fn post_bundle(&mut self, trevm: &EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error>;
 }

--- a/src/driver/chain.rs
+++ b/src/driver/chain.rs
@@ -8,17 +8,21 @@ pub type DriveChainResult<Db, Insp, D> =
     Result<EvmNeedsBlock<Db, Insp>, EvmChainDriverErrored<Db, Insp, D>>;
 
 /// Driver for a chain of blocks.
-pub trait ChainDriver<Insp> {
+pub trait ChainDriver<Db, Insp>
+where
+    Db: Database + DatabaseCommit,
+    Insp: Inspector<Ctx<Db>>,
+{
     /// The block driver for this chain.
-    type BlockDriver: BlockDriver<Insp>;
+    type BlockDriver: BlockDriver<Db, Insp>;
 
     /// An error type for this driver.
-    type Error<Db: Database + DatabaseCommit>: core::error::Error
+    type Error: core::error::Error
         + From<EVMError<Db::Error>>
-        + From<<Self::BlockDriver as BlockDriver<Insp>>::Error<Db>>;
+        + From<<Self::BlockDriver as BlockDriver<Db, Insp>>::Error>;
 
     /// Get the spec id for a block.
-    fn spec_id_for(&self, block: &<Self::BlockDriver as BlockDriver<Insp>>::Block) -> SpecId;
+    fn spec_id_for(&self, block: &<Self::BlockDriver as BlockDriver<Db, Insp>>::Block) -> SpecId;
 
     /// Get the blocks in this chain. The blocks should be in order, and this
     /// function MUST NOT return an empty slice.
@@ -28,12 +32,9 @@ pub trait ChainDriver<Insp> {
     /// or parent-child relationships.
     ///
     /// The `idx` parameter is the index of the block in the chain.
-    fn interblock<Db>(
+    fn interblock(
         &mut self,
         trevm: &EvmNeedsBlock<Db, Insp>,
         idx: usize,
-    ) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        Insp: Inspector<Ctx<Db>>;
+    ) -> Result<(), Self::Error>;
 }

--- a/src/est.rs
+++ b/src/est.rs
@@ -240,7 +240,7 @@ impl EstimationResult {
     }
 
     /// Adjust the binary search range based on the estimation outcome.
-    pub(crate) fn adjust_binary_search_range(
+    pub(crate) const fn adjust_binary_search_range(
         &self,
         limit: u64,
         range: &mut SearchRange,

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1935,7 +1935,7 @@ where
     /// This is primarily intended for use in [`SystemTx`] execution.
     ///
     /// [`SystemTx`]: crate::system::SystemTx
-    pub fn result_mut_unchecked(&mut self) -> &mut ExecutionResult {
+    pub const fn result_mut_unchecked(&mut self) -> &mut ExecutionResult {
         &mut self.state.result.result
     }
 
@@ -1946,7 +1946,7 @@ where
 
     /// Get a mutable reference to the state. Modification of the state is
     /// discouraged, as it may lead to inconsistent state.
-    pub fn state_mut_unchecked(&mut self) -> &mut EvmState {
+    pub const fn state_mut_unchecked(&mut self) -> &mut EvmState {
         &mut self.state.result.state
     }
 
@@ -1961,7 +1961,7 @@ where
     /// This is primarily intended for use in [`SystemTx`] execution.
     ///
     /// [`SystemTx`]: crate::system::SystemTx
-    pub fn result_and_state_mut_unchecked(&mut self) -> &mut ResultAndState {
+    pub const fn result_and_state_mut_unchecked(&mut self) -> &mut ResultAndState {
         &mut self.state.result
     }
 

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -977,7 +977,7 @@ where
     /// block.
     pub fn drive_block<D>(self, driver: &mut D) -> DriveBlockResult<Db, Insp, D>
     where
-        D: BlockDriver<Insp>,
+        D: BlockDriver<Db, Insp>,
         Db: DatabaseCommit,
     {
         let trevm = self.fill_block(driver.block());
@@ -998,14 +998,14 @@ where
     /// If the driver contains no blocks.
     pub fn drive_chain<D>(self, driver: &mut D) -> DriveChainResult<Db, Insp, D>
     where
-        D: ChainDriver<Insp>,
+        D: ChainDriver<Db, Insp>,
         Db: DatabaseCommit,
     {
         let block_count = driver.blocks().len();
 
         let mut trevm = self
             .drive_block(&mut driver.blocks()[0])
-            .map_err(EvmErrored::err_into::<<D as ChainDriver<Insp>>::Error<Db>>)?;
+            .map_err(EvmErrored::err_into::<<D as ChainDriver<Db, Insp>>::Error>)?;
 
         if let Err(e) = driver.interblock(&trevm, 0) {
             return Err(trevm.errored(e));
@@ -1015,7 +1015,7 @@ where
             trevm = {
                 let trevm = trevm
                     .drive_block(&mut driver.blocks()[i])
-                    .map_err(EvmErrored::err_into::<<D as ChainDriver<Insp>>::Error<Db>>)?;
+                    .map_err(EvmErrored::err_into::<<D as ChainDriver<Db, Insp>>::Error>)?;
                 if let Err(e) = driver.interblock(&trevm, i) {
                     return Err(trevm.errored(e));
                 }
@@ -1184,7 +1184,7 @@ where
     /// EVM ready for the next bundle or tx.
     pub fn drive_bundle<D>(self, driver: &mut D) -> DriveBundleResult<Db, Insp, D>
     where
-        D: BundleDriver<Insp>,
+        D: BundleDriver<Db, Insp>,
         Db: DatabaseCommit,
     {
         let trevm = driver.run_bundle(self)?;

--- a/src/inspectors/layer.rs
+++ b/src/inspectors/layer.rs
@@ -48,7 +48,7 @@ impl<Outer, Inner> Layered<Outer, Inner> {
     }
 
     /// Get a mutable reference to the current inspector.
-    pub fn outer_mut(&mut self) -> &mut Outer {
+    pub const fn outer_mut(&mut self) -> &mut Outer {
         &mut self.outer
     }
 
@@ -58,7 +58,7 @@ impl<Outer, Inner> Layered<Outer, Inner> {
     }
 
     /// Get a mutable reference to the inner inspector.
-    pub fn inner_mut(&mut self) -> &mut Inner {
+    pub const fn inner_mut(&mut self) -> &mut Inner {
         &mut self.inner
     }
 }

--- a/src/journal/index.rs
+++ b/src/journal/index.rs
@@ -38,7 +38,6 @@ pub enum InfoOutcome<'a> {
 impl InfoOutcome<'_> {
     /// Get the original account info. This is `None` if the account was
     /// created.
-    // #[allow(clippy::missing_const_for_fn)] // false positive
     pub const fn original(&self) -> Option<Cow<'_, AccountInfo>> {
         match self {
             Self::Created(_) => None,

--- a/src/journal/index.rs
+++ b/src/journal/index.rs
@@ -38,11 +38,14 @@ pub enum InfoOutcome<'a> {
 impl InfoOutcome<'_> {
     /// Get the original account info. This is `None` if the account was
     /// created.
-    pub fn original(&self) -> Option<Cow<'_, AccountInfo>> {
+    // #[allow(clippy::missing_const_for_fn)] // false positive
+    pub const fn original(&self) -> Option<Cow<'_, AccountInfo>> {
         match self {
             Self::Created(_) => None,
-            Self::Diff { old, .. } => Some(Cow::Borrowed(old)),
-            Self::Destroyed(info) => Some(Cow::Borrowed(info)),
+            Self::Diff { old: Cow::Owned(old), .. } => Some(Cow::Borrowed(old)),
+            Self::Diff { old: Cow::Borrowed(old), .. } => Some(Cow::Borrowed(*old)),
+            Self::Destroyed(Cow::Owned(old)) => Some(Cow::Borrowed(old)),
+            Self::Destroyed(Cow::Borrowed(old)) => Some(Cow::Borrowed(*old)),
         }
     }
 
@@ -96,7 +99,7 @@ pub struct AcctDiff<'a> {
 impl AcctDiff<'_> {
     /// Get the original account info. This is `None` if the account was
     /// created.
-    pub fn original(&self) -> Option<Cow<'_, AccountInfo>> {
+    pub const fn original(&self) -> Option<Cow<'_, AccountInfo>> {
         self.outcome.original()
     }
 

--- a/src/lifecycle/output.rs
+++ b/src/lifecycle/output.rs
@@ -58,6 +58,7 @@ impl<T: TxReceipt<Log = alloy::primitives::Log>> BlockOutput<T> {
     }
 
     /// Get a reference to the receipts of the transactions in the block.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn receipts(&self) -> &[T] {
         &self.receipts
     }
@@ -74,6 +75,7 @@ impl<T: TxReceipt<Log = alloy::primitives::Log>> BlockOutput<T> {
     }
 
     /// Get a reference the senders of the transactions in the block.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn senders(&self) -> &[Address] {
         &self.senders
     }

--- a/src/states.rs
+++ b/src/states.rs
@@ -57,19 +57,19 @@ pub type EvmErrored<Db, Insp, E = EVMError<<Db as Database>::Error>> =
 ///
 /// This is an [`EvmErrored`] parameterized with the driver's error type.
 pub type EvmBlockDriverErrored<Db, Insp, T> =
-    EvmErrored<Db, Insp, <T as BlockDriver<Insp>>::Error<Db>>;
+    EvmErrored<Db, Insp, <T as BlockDriver<Db, Insp>>::Error>;
 
 /// A [`Trevm`] that encountered an error during [`ChainDriver`] execution.
 ///
 /// This is an [`EvmErrored`] parameterized with the driver's error type.
 pub type EvmChainDriverErrored<Db, Insp, T> =
-    EvmErrored<Db, Insp, <T as ChainDriver<Insp>>::Error<Db>>;
+    EvmErrored<Db, Insp, <T as ChainDriver<Db, Insp>>::Error>;
 
 /// A [`Trevm`] that encountered an error during [`BundleDriver`] execution.
 ///
 /// This is an [`EvmErrored`] parameterized with the driver's error type.
 pub type EvmBundleDriverErrored<Db, Insp, T> =
-    EvmErrored<Db, Insp, <T as BundleDriver<Insp>>::Error<Db>>;
+    EvmErrored<Db, Insp, <T as BundleDriver<Db, Insp>>::Error>;
 
 #[allow(unnameable_types, dead_code, unreachable_pub)]
 pub(crate) mod sealed {


### PR DESCRIPTION
Put the DB back in the driver traits to handle new Inspector trait generics 