### PR TITLE
chore(docs): remove doc_auto_cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trevm"
-version = "0.30.0"
+version = "0.30.1"
 rust-version = "1.83.0"
 edition = "2021"
 authors = ["init4"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![warn(missing_docs, missing_copy_implementations, missing_debug_implementations)]
 


### PR DESCRIPTION
This is causing the docs build to fail for the latest trevm.

Closes #129 