### PR TITLE
feat: add "needs db" type state to `TrevmBuilder`

### DIFF
--- a/examples/basic_transact.rs
+++ b/examples/basic_transact.rs
@@ -39,7 +39,7 @@ impl Tx for SampleTx {
 // Produce aliases for the Trevm type
 trevm_aliases!(TracerEip3155, InMemoryDB);
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     let mut db = revm::database::InMemoryDB::default();
 
     let bytecode = Bytecode::new_raw(hex::decode(CONTRACT_BYTECODE).unwrap().into());
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trevm = TrevmBuilder::new()
         .with_db(db)
         .with_insp(insp)
-        .build_trevm()?
+        .build_trevm()
         .fill_cfg(&NoopCfg)
         .fill_block(&NoopBlock);
 
@@ -72,6 +72,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Execution error: {e:?}");
         }
     };
-
-    Ok(())
 }

--- a/examples/fork_ref_transact.rs
+++ b/examples/fork_ref_transact.rs
@@ -60,7 +60,7 @@ async fn main() -> eyre::Result<()> {
     // initialise an empty (default) EVM
     let evm = TrevmBuilder::new()
         .with_db(cache_db)
-        .build_trevm()?
+        .build_trevm()
         .fill_cfg(&NoopCfg)
         .fill_block(&NoopBlock)
         .fill_tx(&GetReservesFiller)

--- a/src/evm/has_tx.rs
+++ b/src/evm/has_tx.rs
@@ -264,8 +264,7 @@ mod tests {
         let log_address = Address::repeat_byte(0x32);
 
         // Set up trevm, and test balances.
-        let mut trevm =
-            TrevmBuilder::new().with_db(db).with_spec_id(SpecId::PRAGUE).build_trevm().unwrap();
+        let mut trevm = TrevmBuilder::new().with_db(db).with_spec_id(SpecId::PRAGUE).build_trevm();
         let _ = trevm.test_set_balance(ALICE.address(), U256::from(ETH_TO_WEI));
         let _ = trevm.set_bytecode_unchecked(log_address, Bytecode::new_raw(LOG_DEPLOYED_BYTECODE));
 

--- a/src/inspectors/mod.rs
+++ b/src/inspectors/mod.rs
@@ -35,7 +35,6 @@ mod test {
             .with_db(InMemoryDB::default())
             .with_insp(inspector)
             .build_trevm()
-            .unwrap()
             .fill_cfg(&NoopCfg)
             .fill_block(&NoopBlock);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,15 +41,13 @@
 //! use revm::{database::in_memory_db::InMemoryDB};
 //! use trevm::{TrevmBuilder, EvmErrored, Cfg, Block, Tx};
 //!
-//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T)
-//! # -> Result<(), Box<dyn std::error::Error>> {
+//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T) {
 //! TrevmBuilder::new()
 //!     .with_db(InMemoryDB::default())
-//!     .build_trevm()?
+//!     .build_trevm()
 //!     .fill_cfg(cfg)
 //!     .fill_block(block)
 //!     .run_tx(tx);
-//! # Ok(())
 //! # }
 //! ```
 //! If you get stuck, don't worry! You _cannot_ invoke the wrong function or
@@ -118,14 +116,12 @@
 //! # use revm::{database::in_memory_db::InMemoryDB, inspector::NoOpInspector};
 //! # use trevm::{TrevmBuilder, EvmErrored, Cfg, BlockDriver};
 //! # use alloy::primitives::B256;
-//! # fn t<C: Cfg, D: BlockDriver<InMemoryDB, NoOpInspector>>(cfg: &C, mut driver: D)
-//! # -> Result<(), Box<dyn std::error::Error>> {
+//! # fn t<C: Cfg, D: BlockDriver<InMemoryDB, NoOpInspector>>(cfg: &C, mut driver: D) {
 //! let trevm = TrevmBuilder::new()
 //!     .with_db(InMemoryDB::default())
-//!     .build_trevm()?
+//!     .build_trevm()
 //!     .fill_cfg(cfg)
 //!     .drive_block(&mut driver);
-//! # Ok(())
 //! # }
 //! ```
 //!
@@ -148,11 +144,10 @@
 //! # use revm::{database::in_memory_db::InMemoryDB};
 //! # use trevm::{TrevmBuilder, EvmErrored, Cfg, Block, Tx};
 //! # use alloy::primitives::B256;
-//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T)
-//! # -> Result<(), Box<dyn std::error::Error>> {
+//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T) {
 //! let trevm = match TrevmBuilder::new()
 //!     .with_db(InMemoryDB::default())
-//!     .build_trevm()?
+//!     .build_trevm()
 //!     .fill_cfg(cfg)
 //!     .fill_block(block)
 //!     .fill_tx(tx)
@@ -160,7 +155,6 @@
 //!         Ok(trevm) => trevm.accept_state(),
 //!         Err(e) => e.discard_error(),
 //!     };
-//! # Ok(())
 //! # }
 //! ```
 //!
@@ -245,14 +239,13 @@
 //! # State, StateBuilder}};
 //! # use trevm::{TrevmBuilder, EvmErrored, Cfg, Block, Tx, BlockOutput,
 //! # EvmNeedsCfg, EvmNeedsBlock, EvmNeedsTx, EvmReady, EvmTransacted};
-//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T)
-//! # -> Result<(), Box<dyn std::error::Error>> {
+//! # fn t<C: Cfg, B: Block, T: Tx>(cfg: &C, block: &B, tx: &T) {
 //! let state = StateBuilder::new_with_database(InMemoryDB::default()).build();
 //!
 //! // Trevm starts in `EvmNeedsCfg`.
 //! let trevm: EvmNeedsCfg<_, _> = TrevmBuilder::new()
 //!     .with_db(state)
-//!     .build_trevm()?;
+//!     .build_trevm();
 //!
 //! // Once the cfg is filled, we move to `EvmNeedsBlock`.
 //! let trevm: EvmNeedsBlock<_, _> = trevm.fill_cfg(cfg);
@@ -285,7 +278,6 @@
 //! // Finishing the EVM gets us the final changes and a list of block outputs
 //! // that includes the transaction receipts.
 //! let bundle: BundleState = trevm.finish();
-//! # Ok(())
 //! # }
 //! ```
 //!


### PR DESCRIPTION
Hey, was trying out the library and noticed that `build_trevm` was fallible when it didn't need to be. Let me know if this change is desired.